### PR TITLE
Implement evolution

### DIFF
--- a/src/scripts/pokemons/CaughtPokemon.ts
+++ b/src/scripts/pokemons/CaughtPokemon.ts
@@ -22,10 +22,11 @@ class CaughtPokemon {
         this.baseAttack = pokemonData.attack
         this.attack = ko.computed(() => {return PokemonHelper.calculateAttack(this.baseAttack, this.attackBonus(), this.levelObservable())})
 
-        if (pokemonData.evoLevel && this.levelObservable() < pokemonData.evoLevel) {
+        if (pokemonData.evoLevel && !this.evolved) {
             this.evolver = this.levelObservable.subscribe(() => {
                 if (this.levelObservable() >= pokemonData.evoLevel) {
                     Player.capturePokemon(pokemonData.evolution, false);
+                    this.evolved = true;
                     this.evolver.dispose();
                 }
             })

--- a/src/scripts/pokemons/CaughtPokemon.ts
+++ b/src/scripts/pokemons/CaughtPokemon.ts
@@ -10,6 +10,7 @@ class CaughtPokemon {
     attackBonus: KnockoutObservable<number>;
     exp: KnockoutObservable<number>;
     levelObservable: KnockoutComputed<number>;
+    evolver: KnockoutSubscription
 
     constructor(pokemonData: DataPokemon, ev: boolean, atBo: number, xp: number) {
         this.id = pokemonData.id;
@@ -20,5 +21,14 @@ class CaughtPokemon {
         this.levelObservable = ko.computed(() => {return PokemonHelper.calculateLevel(this)});
         this.baseAttack = pokemonData.attack
         this.attack = ko.computed(() => {return PokemonHelper.calculateAttack(this.baseAttack, this.attackBonus(), this.levelObservable())})
+
+        if (pokemonData.evoLevel) {
+            this.evolver = this.levelObservable.subscribe(() => {
+                if (this.levelObservable() >= pokemonData.evoLevel) {
+                    Player.capturePokemon(pokemonData.evolution, false);
+                    this.evolver.dispose();
+                }
+            })
+        }
     }
 }

--- a/src/scripts/pokemons/CaughtPokemon.ts
+++ b/src/scripts/pokemons/CaughtPokemon.ts
@@ -22,7 +22,7 @@ class CaughtPokemon {
         this.baseAttack = pokemonData.attack
         this.attack = ko.computed(() => {return PokemonHelper.calculateAttack(this.baseAttack, this.attackBonus(), this.levelObservable())})
 
-        if (pokemonData.evoLevel) {
+        if (pokemonData.evoLevel && this.levelObservable() < pokemonData.evoLevel) {
             this.evolver = this.levelObservable.subscribe(() => {
                 if (this.levelObservable() >= pokemonData.evoLevel) {
                     Player.capturePokemon(pokemonData.evolution, false);


### PR DESCRIPTION
Pokemon now evolve when they reach the appropriate level, only check when they gain a level, and don't checkever again after they have evolved.

Was the evolved boolean on CaughtPokemon only there to skip evolution checks? If so it is not needed with this method and can be removed.