### PR TITLE
Use badge name instead of number for locked dungeon notification

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -29,7 +29,7 @@ class Dungeon {
 
     public isUnlocked(): boolean {
         if(!player.hasBadge(this.badgeReq)){
-            Notifier.notify("You need the " + this.badgeReq + " badge to access this dungeon", GameConstants.NotificationOption.danger);
+            Notifier.notify("You need the " + GameConstants.Badge[this.badgeReq] + " badge to access this dungeon", GameConstants.NotificationOption.danger);
             return false;
         }
 


### PR DESCRIPTION
"You need the Rainbow badge to access this dungeon" instead of "You need the 4 badge to access this dungeon"