### PR TITLE
Fix Sprayduck id

### DIFF
--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -40,7 +40,7 @@ namespace GameConstants {
         "Amulet Coin",
         "Poison Barb",
         "Exp Share",
-        "Plant Grower",
+        "Sprayduck",
         "Shiny Charm",
         "Blaze Cassette",
         "Cell Battery",


### PR DESCRIPTION
The id for Sprayduck wasn't getting set due a name change, causing getOakItemExp to throw an error.