### PR TITLE
Pokemon list is smaller and even smaller on small screens

### DIFF
--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -129,8 +129,14 @@ body:hover {
 }
 
 .pokemon-list-container {
-  max-height: 515px;
+  max-height: 300px;
   overflow: auto;
+}
+
+@media (min-width: 992px) {
+  .pokemon-list-container {
+    max-height: 400px;
+  }
 }
 
 #pokemonList {


### PR DESCRIPTION
closes #132 
The scroll bar is now gone on large screens. Tested on both chrome and firefox