### PR TITLE
Chat System V1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,9 +33,7 @@ const srcs = {
             'node_modules/jquery/dist/jquery.min.js',
             'node_modules/tether/dist/js/tether.min.js',
             'node_modules/knockout/build/output/knockout-latest.js',
-            'node_modules/bootstrap-notify/bootstrap-notify.min.js',
-            'src/libs/converse.css',
-            'src/libs/converse.js'
+            'node_modules/bootstrap-notify/bootstrap-notify.min.js'
     ]
 };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,9 @@ const srcs = {
             'node_modules/jquery/dist/jquery.min.js',
             'node_modules/tether/dist/js/tether.min.js',
             'node_modules/knockout/build/output/knockout-latest.js',
-            'node_modules/bootstrap-notify/bootstrap-notify.min.js'
+            'node_modules/bootstrap-notify/bootstrap-notify.min.js',
+            'src/libs/converse.css',
+            'src/libs/converse.js'
     ]
 };
 

--- a/src/index.html
+++ b/src/index.html
@@ -74,6 +74,10 @@
     <!--Minified styles-->
     <link href="styles/styles.min.css" rel="stylesheet">
 
+    <!--converse chat-->
+    <link rel="stylesheet" type="text/css" media="screen" href="https://cdn.conversejs.org/css/converse.min.css">
+    <script src="https://cdn.conversejs.org/dist/converse.min.js"></script>
+
 </head>
 <body class="no-select">
 @import "splash.html"
@@ -1164,4 +1168,10 @@
 @import "farmModal.html"
 
 </body>
+<script>
+    converse.initialize({
+        bosh_service_url: 'https://conversejs.org/http-bind/', // Please use this connection manager only for testing purposes
+        show_controlbox_by_default: true
+    });
+</script>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -1170,7 +1170,7 @@
 </body>
 <script>
     converse.initialize({
-        bosh_service_url: 'https://conversejs.org/http-bind/', // Please use this connection manager only for testing purposes
+        bosh_service_url: 'http://104.131.157.131:7070/http-bind/', // Please use this connection manager only for testing purposes
         show_controlbox_by_default: true
     });
 </script>

--- a/src/index.html
+++ b/src/index.html
@@ -1186,16 +1186,25 @@
         muc_show_join_leave : false,
         muc_domain : "conference.localhoststudios.com",
         auto_join_rooms : [{'jid': 'pokeclicker@conference.localhoststudios.com' }],
+        use_vcards : false,
         visible_toolbar_buttons : {
             call: false,
             clear: false,
             emoji: true,
-            toggle_occupants: true
+            toggle_occupants: false
         }
      });    
 </script>
 </html>
 
 <style>
-    #chatrooms form {display:none !important;}
+    #chatrooms form, .occupants, #converse-roster {display:none !important;}
+    .chat-area {min-width:100% !important;}
+    #controlbox {width:300px !important;}
+    .flyout.box-flyout {width:300px !important;}
+    #converse-register .input-group span {display:none !important;}
+    #available-chatrooms dt {display:none !important;}
+    .open-rooms-list.rooms-list-container {display:none !important;}
+    .change-xmpp-status-message.icon-pencil {display:none !important;}
+    #conversejs {font-family: pokemonFont !important; font-size:14px !important;}
 </style>

--- a/src/index.html
+++ b/src/index.html
@@ -1170,8 +1170,32 @@
 </body>
 <script>
     converse.initialize({
-        bosh_service_url: 'http://104.131.157.131:7070/http-bind/', // Please use this connection manager only for testing purposes
-        show_controlbox_by_default: true
-    });
+        bosh_service_url: 'http://chat.localhoststudios.com:7070/http-bind/', // Please use this connection manager only for testing purposes
+        show_controlbox_by_default: false,
+        locked_domain : "localhoststudios.com",
+        registration_domain : "localhoststudios.com",
+        default_domain : "localhoststudios.com",
+        allow_otr : false,
+        muc_nickname_from_jid : true,
+        allow_contact_requests : false,
+        allow_muc_invitations : false,
+        allow_bookmarks : false,
+        auto_list_rooms : true,
+        hide_muc_server : true,
+        muc_instant_rooms : false,
+        muc_show_join_leave : false,
+        muc_domain : "conference.localhoststudios.com",
+        auto_join_rooms : [{'jid': 'pokeclicker@conference.localhoststudios.com' }],
+        visible_toolbar_buttons : {
+            call: false,
+            clear: false,
+            emoji: true,
+            toggle_occupants: true
+        }
+     });    
 </script>
 </html>
+
+<style>
+    #chatrooms form {display:none !important;}
+</style>


### PR DESCRIPTION
Still uses CDN. I recommend leaving it that way and build an override stylesheet to include later.
Notes:

- Locked down to only one server domain
- Auto joins default Pokeclicker room on register
- Auto popup of Pokeclicker room on register and sign in while collapsing main bar
- Disables encryption
- Auto uses nickname from login when joining room
- Disables contact requests
- Disables bookmarks
- Disables ability to leave room (can close, but reopen on refresh or through rooms tab)
- Disables clear message command in chat room
- Disables user created chatrooms (Some override style applied to disable chatroom form as it is not a config option)
