### PR TITLE
removed shards title - leaving h4 to preserve help location

### DIFF
--- a/src/components/shards.html
+++ b/src/components/shards.html
@@ -2,7 +2,7 @@
     <div class="modal-dialog" id="shardModalDialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title">Shards</h4>
+                <h4 class="modal-title"></h4>
                 <img style="float:right;margin-right:10px;"
                      data-bind="tooltip: { title: 'Use shards to upgrade the type effectiveness of your Pokémon. When you defeat a Pokémon, you get shards based on its type. ', trigger: 'hover', placement:'right' }"
                      src="assets/images/questionmark.png">


### PR DESCRIPTION
per issue #204 - removed shards title. if we remove the h4 element - help img moves to the left - not sure if we want it that way or not - and easiest path is to empty the h4 as opposed to remove and fix help css.