### PR TITLE
pokedex should show only highest encountered

### DIFF
--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -48,6 +48,14 @@ class PokedexHelper {
 
     public static getList(): Array<object> {
         let filter = PokedexHelper.getFilters();
+
+        let highestDefeated = 0;
+        pokemonList.filter(function(pokemon){
+            if(player.defeatedAmount[pokemon.id]() != 0 && pokemon.id > highestDefeated) {
+                highestDefeated = pokemon.id;
+            }
+        })
+
         return pokemonList.filter(function (pokemon) {
             if ((filter['name'] || "") != "" && pokemon.name.toLowerCase().indexOf(filter['name'].toLowerCase()) == -1) {
                 return false;
@@ -71,6 +79,10 @@ class PokedexHelper {
             }
 
             if (filter['uncaught'] && player.caughtAmount[pokemon.id]() !== 0) {
+                return false;
+            }
+
+            if (pokemon.id > highestDefeated) {
                 return false;
             }
 


### PR DESCRIPTION
This is completed per #204 - to have the dex only show highest encountered pokemon. However I do not see anything in the code that actively refreshes the pokedex outside of onload of the game as a whole. This is most likely because we showed the entire dex before. We should maybe add some logic to update the dex once the modal is opened. Will create separate issue for that one.