### PR TITLE
Oak items now save correctly

### DIFF
--- a/src/scripts/oakitems/OakItemRunner.ts
+++ b/src/scripts/oakitems/OakItemRunner.ts
@@ -35,6 +35,9 @@ class OakItemRunner {
         for (let i = 0; i < player._oakItemsEquipped.length; i++) {
             OakItemRunner.activateOakItem(OakItemRunner.getOakItemByName(player._oakItemsEquipped[i]).id);
         }
+        for(let i = 0; i<OakItemRunner.oakItemList.length; i++){
+            OakItemRunner.oakItemList[i]().calculateLevel();
+        }
     }
 
     public static hover(name: string) {


### PR DESCRIPTION
They actually saved correctly already, but now they recalculate their own level after loading. Closes #196 