### PR TITLE
hacked money fix maybe?

### DIFF
--- a/src/scripts/Main.ts
+++ b/src/scripts/Main.ts
@@ -169,6 +169,10 @@ class Game {
         if (GameHelper.counter > 60 * 1000) {
             GameHelper.updateTime();
         }
+
+        if ($('#playerMoney').text() == "0" && player.hasKeyItem("Town Map")){
+            Game.updateMoneyNoAnimate();
+        }
     }
 
     save() {
@@ -188,6 +192,7 @@ class Game {
             QuestLineHelper.createTutorial();
             QuestLineHelper.tutorial.resumeAt(player.tutorialProgress(), player.tutorialState);
         }
+        Game.updateMoneyNoAnimate();
     }
 
     static applyRouteBindings() {
@@ -208,6 +213,10 @@ class Game {
 
     static updateMoney(text: string = $("#playerMoney").text()) {
         $("#playerMoney").prop('number', text).animateNumber({number: player.money});
+    }
+
+    static updateMoneyNoAnimate(){
+        $('#playerMoney').text(player.money); 
     }
 
 


### PR DESCRIPTION
ok - so the way this issue happens is strange. when game state changes to town or dungeon - the player money display goes back to 0. so knockout apparently does not have access anymore or chooses not to update. no clue as to why.
 
since gamestate is not a function and just a value we are setting - we cant hook an update money function to it.

first issue is the updateMoney function - the function has animate baked in now - so if we did hook it in - you would be animating the money each time moving from shop to town or town back to route etc. 

I created a new function called updateMoneyNoAnimate to update the money without animation.

Then to hook it in - i updated the tick function to check if the displayed money is 0 and if the player has the town map. the town map is important because this issue does not exist until the map is obtained and the user will always have money right before acquiring the map. the first time this would ever fire is when you get the town map and click into a town or dungeon - it will see on 1 single tick the money is 0 and you have the map and then update the value again. then the updatenoanimate will not fire again as the check continues to be false. 

its definitely a hack - but it works and is agnostic to whatever additional states cause this issue. id rather fix the root cause with knockout but no clue what it is so feel free to find out later.