### PR TITLE
Alt fix/money animation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -145,13 +145,13 @@
                                 <td width="33.33%">
                                     <span style="display: inline;">
                                         <img title="Dungeon Tokens" src="assets/images/currency/dungeonToken.png">
-                                        <span data-bind="text: player.dungeonTokens">Not yet</span>
+                                        <span id="playerMoneyDungeon" data-bind="text: player.dungeonTokens">Not yet</span>
                                     </span>
                                 </td>
                                 <td width="33.33%">
                                     <span style="display: inline;">
                                         <img title="Quest points" src="assets/images/currency/questPoint.png">
-                                        <span data-bind="text: player.questPoints">Not yet</span>
+                                        <span id="playerMoneyQuest" data-bind="text: player.questPoints">Not yet</span>
                                     </span>
                                 </td>
                             </tr>

--- a/src/index.html
+++ b/src/index.html
@@ -139,7 +139,7 @@
                                 <td width="33.33%">
                                     <span style="display: inline;">
                                         <img title="Money" src="assets/images/currency/money.png">
-                                        <span id="playerMoney">0</span>
+                                        <span id="playerMoney" data-bind="text: player.money">0</span>
                                     </span>
                                 </td>
                                 <td width="33.33%">

--- a/src/index.html
+++ b/src/index.html
@@ -58,9 +58,6 @@
     <!--jQuery-->
     <script src="libs/jquery.min.js"></script>
 
-    <!--AnimateNumber-->
-    <script src="libs/jquery.animateNumber.min.js"></script>
-
     <!--Knockout-->
     <script src="libs/knockout-latest.js"></script>
 

--- a/src/libs/jquery.animateNumber.min.js
+++ b/src/libs/jquery.animateNumber.min.js
@@ -1,8 +1,0 @@
-/*
- jQuery animateNumber plugin v0.0.14
- (c) 2013, Alexandr Borisov.
- https://github.com/aishek/jquery-animateNumber
-*/
-(function(d){var r=function(b){return b.split("").reverse().join("")},m={numberStep:function(b,a){var e=Math.floor(b);d(a.elem).text(e)}},g=function(b){var a=b.elem;a.nodeType&&a.parentNode&&(a=a._animateNumberSetter,a||(a=m.numberStep),a(b.now,b))};d.Tween&&d.Tween.propHooks?d.Tween.propHooks.number={set:g}:d.fx.step.number=g;d.animateNumber={numberStepFactories:{append:function(b){return function(a,e){var f=Math.floor(a);d(e.elem).prop("number",a).text(f+b)}},separator:function(b,a,e){b=b||" ";
-            a=a||3;e=e||"";return function(f,k){var u=0>f,c=Math.floor((u?-1:1)*f).toString(),n=d(k.elem);if(c.length>a){for(var h=c,l=a,m=h.split("").reverse(),c=[],p,s,q,t=0,g=Math.ceil(h.length/l);t<g;t++){p="";for(q=0;q<l;q++){s=t*l+q;if(s===h.length)break;p+=m[s]}c.push(p)}h=c.length-1;l=r(c[h]);c[h]=r(parseInt(l,10).toString());c=c.join(b);c=r(c)}n.prop("number",f).text((u?"-":"")+c+e)}}}};d.fn.animateNumber=function(){for(var b=arguments[0],a=d.extend({},m,b),e=d(this),f=[a],k=1,g=arguments.length;k<g;k++)f.push(arguments[k]);
-    if(b.numberStep){var c=this.each(function(){this._animateNumberSetter=b.numberStep}),n=a.complete;a.complete=function(){c.each(function(){delete this._animateNumberSetter});n&&n.apply(this,arguments)}}return e.animate.apply(e,f)}})(jQuery);

--- a/src/scripts/Main.ts
+++ b/src/scripts/Main.ts
@@ -228,7 +228,7 @@ class Game {
         $(ani).prependTo('body').animate({
             top: -100,
             opacity: 0
-        }, 250 * Math.log(money) + 50,"linear",
+        }, 250 * Math.log(money) + 150,"linear",
             function() {
         $(this).remove();
         });

--- a/src/scripts/Main.ts
+++ b/src/scripts/Main.ts
@@ -217,7 +217,7 @@ class Game {
         }else{
             pos = {"top":-200, "left":0};
         }
-        
+
         let left= ((Math.random() * ((pos.left + 25) - (pos.left - 25)) + (pos.left - 25))).toFixed(2);
         let place = money.toString().length;
         let multi = 1;
@@ -227,8 +227,8 @@ class Game {
         let ani = '<p class="moneyanimation" style="z-index:50;position:fixed;left:'+left+'px;top:'+pos.top+'px;">+'+money+'</p>';
         $(ani).prependTo('body').animate({
             top: -100,
-            opacity: 0 
-        }, 250 * Math.log(money),"linear",
+            opacity: 0
+        }, 250 * Math.log(money) + 50,"linear",
             function() {
         $(this).remove();
         });

--- a/src/scripts/Main.ts
+++ b/src/scripts/Main.ts
@@ -210,15 +210,21 @@ class Game {
         $("#playerMoney").prop('number', player.money);
     }
 
-    static animateMoney(money){
-        let pos = $('#playerMoney').offset();
+    static animateMoney(money,target){
+        let pos;
+        if($('#'+target).offset()){
+            pos = $('#'+target).offset();
+        }else{
+            pos = {"top":-200, "left":0};
+        }
+        
         let left= ((Math.random() * ((pos.left + 25) - (pos.left - 25)) + (pos.left - 25))).toFixed(2);
-        var place = money.toString().length;
-        var multi = 1;
-        for(var i = 0; i < place; i++){
+        let place = money.toString().length;
+        let multi = 1;
+        for(let i = 0; i < place; i++){
             multi *= 10;
         }
-        var ani = '<p class="moneyanimation" style="z-index:50;position:fixed;left:'+left+'px;top:'+pos.top+'px;">+'+money+'</p>';
+        let ani = '<p class="moneyanimation" style="z-index:50;position:fixed;left:'+left+'px;top:'+pos.top+'px;">+'+money+'</p>';
         $(ani).prependTo('body').animate({
             top: -100,
             opacity: 0 

--- a/src/scripts/Main.ts
+++ b/src/scripts/Main.ts
@@ -233,10 +233,4 @@ class Game {
         $(this).remove();
         });
     }
-
-    static map (num, in_min, in_max, out_min, out_max) {
-        return (num - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
-      }
-
 }
-

--- a/src/scripts/Main.ts
+++ b/src/scripts/Main.ts
@@ -207,9 +207,30 @@ class Game {
     }
 
     static updateMoney(text: string = $("#playerMoney").text()) {
-        $("#playerMoney").prop('number', text).animateNumber({number: player.money});
+        $("#playerMoney").prop('number', player.money);
     }
 
+    static animateMoney(money){
+        let pos = $('#playerMoney').offset();
+        let left= ((Math.random() * ((pos.left + 25) - (pos.left - 25)) + (pos.left - 25))).toFixed(2);
+        var place = money.toString().length;
+        var multi = 1;
+        for(var i = 0; i < place; i++){
+            multi *= 10;
+        }
+        var ani = '<p class="moneyanimation" style="z-index:50;position:fixed;left:'+left+'px;top:'+pos.top+'px;">+'+money+'</p>';
+        $(ani).prependTo('body').animate({
+            top: -100,
+            opacity: 0 
+        }, 250 * Math.log(money),"linear",
+            function() {
+        $(this).remove();
+        });
+    }
+
+    static map (num, in_min, in_max, out_min, out_max) {
+        return (num - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+      }
 
 }
 

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -443,6 +443,7 @@ class Player {
         this._money(this._money() + moneytogain);
         GameHelper.incrementObservable(this.statistics.totalMoney, moneytogain);
         Game.updateMoney();
+        Game.animateMoney(moneytogain);
     }
 
     set itemList(value: { [p: string]: KnockoutObservable<number> }) {

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -443,7 +443,7 @@ class Player {
         this._money(this._money() + moneytogain);
         GameHelper.incrementObservable(this.statistics.totalMoney, moneytogain);
         Game.updateMoney();
-        Game.animateMoney(moneytogain);
+        Game.animateMoney(moneytogain,'playerMoney');
     }
 
     set itemList(value: { [p: string]: KnockoutObservable<number> }) {
@@ -626,6 +626,7 @@ class Player {
     public gainDungeonTokens(tokens: number) {
         this._dungeonTokens(Math.floor(this._dungeonTokens() + tokens));
         GameHelper.incrementObservable(this.statistics.totalTokens, tokens);
+        Game.animateMoney(tokens,'playerMoneyDungeon');
     }
 
     get routeKills(): Array<KnockoutObservable<number>> {

--- a/src/scripts/quests/Quest.ts
+++ b/src/scripts/quests/Quest.ts
@@ -28,6 +28,7 @@ abstract class Quest {
     claimReward() {
         if (this.isCompleted()) {
             player.questPoints += this.pointsReward;
+            Game.animateMoney(this.pointsReward,'playerMoneyQuest');
             console.log(`Gained ${this.pointsReward} quest points and ${this.xpReward} xp points`);
             this.claimed(true);
             player.currentQuest(null);


### PR DESCRIPTION
I did not remove the animate number lib as not sure the best way to do so - so @Ishadijcks should do that.

added a new method to animate a floating text when currency, tokens, and qp are added to the user from a state where the currency bar is visible. you can use this method on any object by calling Game.animateMoney(amount,targetid)
