### PR TITLE
Allow for travel between regions

### DIFF
--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -43,6 +43,11 @@
                        onclick="MapHelper.travelToNextRegion()">Go To Next Region
                </button>
            </li>
+           <li class="nav-item" data-bind="if:GameConstants.StartingTowns.indexOf(player.town().name()) > 0">
+            <button class="btn btn-secondary"
+                    onclick="MapHelper.travelToLastRegion()">Go To Last Region
+            </button>
+            </li>
            <div data-bind="if:player.town().dungeon()">
                <li class="nav-item" data-bind="if: player.town() instanceof DungeonTown">
                    <button class="btn btn-secondary"

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -30,8 +30,8 @@ class PokemonHelper {
 
     public static calculateLevel(pokemon: CaughtPokemon): number {
         let level;
-        switch (PokemonHelper.getPokemonByName(pokemon.name).levelType) {
-
+        let type = GameConstants.LevelType[PokemonHelper.getPokemonByName(pokemon.name).levelType];
+        switch (type) {
             case GameConstants.LevelType.slow:
                 level = Math.pow(pokemon.exp() * 4 / 5, 1 / 3);
                 break;
@@ -39,7 +39,7 @@ class PokemonHelper {
                 let y;
                 for (let x = 1; x <= 100; x++) {
                     y = 6 / 5 * Math.pow(x, 3) - 15 * Math.pow(x, 2) + 100 * x - 140;
-                    if (pokemon.exp >= y) {
+                    if (pokemon.exp() >= y) {
                         level = x
                     } else {
                         break;

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -30,8 +30,8 @@ class PokemonHelper {
 
     public static calculateLevel(pokemon: CaughtPokemon): number {
         let level;
-        let type = GameConstants.LevelType[PokemonHelper.getPokemonByName(pokemon.name).levelType];
-        switch (type) {
+        switch (PokemonHelper.getPokemonByName(pokemon.name).levelType) {
+
             case GameConstants.LevelType.slow:
                 level = Math.pow(pokemon.exp() * 4 / 5, 1 / 3);
                 break;
@@ -39,7 +39,7 @@ class PokemonHelper {
                 let y;
                 for (let x = 1; x <= 100; x++) {
                     y = 6 / 5 * Math.pow(x, 3) - 15 * Math.pow(x, 2) + 100 * x - 140;
-                    if (pokemon.exp() >= y) {
+                    if (pokemon.exp >= y) {
                         level = x
                     } else {
                         break;

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -30,7 +30,7 @@ class PokemonHelper {
 
     public static calculateLevel(pokemon: CaughtPokemon): number {
         let level;
-        let type = parseInt(GameConstants.LevelType[PokemonHelper.getPokemonByName(pokemon.name).levelType]);
+        let type = GameConstants.LevelType[PokemonHelper.getPokemonByName(pokemon.name).levelType];
         switch (type) {
             case GameConstants.LevelType.slow:
                 level = Math.pow(pokemon.exp() * 4 / 5, 1 / 3);

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -30,7 +30,7 @@ class PokemonHelper {
 
     public static calculateLevel(pokemon: CaughtPokemon): number {
         let level;
-        let type = GameConstants.LevelType[PokemonHelper.getPokemonByName(pokemon.name).levelType];
+        let type = parseInt(GameConstants.LevelType[PokemonHelper.getPokemonByName(pokemon.name).levelType]);
         switch (type) {
             case GameConstants.LevelType.slow:
                 level = Math.pow(pokemon.exp() * 4 / 5, 1 / 3);

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -135,15 +135,19 @@ class MapHelper {
     }
 
     public static ableToTravel() {
-        return player.caughtPokemonList.length >= GameConstants.pokemonsNeededToTravel[player.highestRegion]
+        return player.caughtPokemonList.length >= GameConstants.pokemonsNeededToTravel[player.region]
     }
 
     public static travelToNextRegion() {
         if (MapHelper.ableToTravel()) {
             player.highestRegion++;
-            MapHelper.moveToTown(GameConstants.StartingTowns[player.highestRegion]);
-            player.region = player.highestRegion;
+            MapHelper.moveToTown(GameConstants.StartingTowns[player.region+1]);
+            player.region = player.region + 1;
         }
+    }
+    public static travelToLastRegion() {
+        MapHelper.moveToTown(GameConstants.StartingTowns[player.region-1])
+        player.region = player.region - 1
     }
 
 }


### PR DESCRIPTION
You were previously able to travel to Johto from Kanto because of the travelToNextRegion function. I realized that there was no invert to this function allowing you to travel back to Johto. This soft locks you from buying things like Pokeballs from the store. This is unless I missed something, in that case, you can disregard this PR.

sidenote - sorry for the dumb amount of commits, I am still learning this branching thing in github :)