### PR TITLE
Add catch rate display in routes and dungeons

### DIFF
--- a/src/components/gymView.html
+++ b/src/components/gymView.html
@@ -1,6 +1,6 @@
 <div id="gymView" data-bind="if: Game.gameState() === GameConstants.GameState.gym">
 
-    <div style="position: relative;">
+    <div style="position:relative; height: 220px;">
         <div id="gymCountdownView">
                 <div class="row" style="display: inline-block; vertical-align: middle;">
                     <div class="col-sm-6 offset-sm-3">
@@ -20,7 +20,7 @@
             <div class="row">
                 <div class="col-sm-4 offset-sm-4">
                     <span data-bind="text: GymBattle.enemyPokemon().name">Pokemon name</span><br>
-                    <div class="clickable" style="height: 96px;">
+                    <div class="clickable">
                         <img id="gymEnemy" src=""
                              data-bind="click: function() {GymBattle.clickAttack()}, attr:{ src: '/assets/images/pokemon/' + GymBattle.enemyPokemon().id + '.png' }"/>
                     </div>
@@ -41,6 +41,11 @@
 
                 </div>
             </div>
+            <div>
+                <span data-bind="text: GymBattle.enemyPokemon().health">health</span>
+                <span>/</span>
+                <span data-bind="text: GymBattle.enemyPokemon().maxHealth">maxHealth</span>
+            </div>
             <div class="progress">
                 <div class="progress-bar bg-danger" role="progressbar"
                      data-bind="attr:{ style: 'width:' + GymBattle.enemyPokemon().healthPercentage() + '%' }"
@@ -49,8 +54,6 @@
                 </div>
             </div>
         </div>
-        <span data-bind="text: GymBattle.enemyPokemon().health">health</span><span>/</span><span
-            data-bind="text: GymBattle.enemyPokemon().maxHealth">maxHealth</span>
     </div>
     <div class="card">
         <table width="100%">

--- a/src/index.html
+++ b/src/index.html
@@ -215,7 +215,7 @@
                                          src=""/>
                                     <br>
                                     Catch Chance: 
-                                    <span data-bind="text: Battle.enemyPokemon().catchRate">Catch Rate</span>%
+                                    <span data-bind="text: Battle.catchRateActual()">Catch Rate</span>%
                                 </div>
                             </div>
                             <div class="progress">
@@ -284,7 +284,7 @@
                                              src=""/>
                                         <br>
                                         Catch Chance: 
-                                        <span data-bind="text: DungeonBattle.enemyPokemon().catchRate">Catch Rate</span>%
+                                        <span data-bind="text: DungeonBattle.catchRateActual()">Catch Rate</span>%
                                     </div>
                                 </div>
                                 <div class="progress">

--- a/src/index.html
+++ b/src/index.html
@@ -162,7 +162,7 @@
                      id="routeBattleView">
 
                     <div data-bind="if: Game.gameState() === GameConstants.GameState.fighting">
-                        <div style="height: 190px; display: block;" class="col-lg-12">
+                        <div style="height: 220px; display: block;" class="col-lg-12">
                             <div class="col-lg-12" style="display: block;">
                                 Route
                                 <span data-bind="text: player.route">number</span>
@@ -198,18 +198,24 @@
                                      src="assets/images/pokeball/Pokeball-shiny-small.png"/>
                             </span>
 
-                            <br>
-                            <div style="height: 96px;">
+                            <div>
                                 <div data-bind="ifnot: Battle.catching">
                                     <img class="clickable" id="enemy"
                                          data-bind="click: function() {Battle.clickAttack()},
                                                     attr:{ src: PokemonHelper.getImage(Battle.enemyPokemon(), Battle.enemyPokemon().shiny) }"
                                          src=""/>
+                                    <br>
+                                    <span data-bind="text: Battle.enemyPokemon().health">health</span>
+                                    <span>/</span>
+                                    <span data-bind="text: Battle.enemyPokemon().maxHealth">maxHealth</span>
                                 </div>
                                 <div data-bind="if: Battle.catching">
                                     <img class="pokeball-animated"
                                          data-bind="attr:{ src: '/assets/images/pokeball/' + GameConstants.Pokeball[Battle.pokeball()] + '.png' }"
                                          src=""/>
+                                    <br>
+                                    Catch Chance: 
+                                    <span data-bind="text: Battle.enemyPokemon().catchRate">Catch Rate</span>%
                                 </div>
                             </div>
                             <div class="progress">
@@ -220,15 +226,11 @@
                                 </div>
                             </div>
                         </div>
-                        <span data-bind="text: Battle.enemyPokemon().health">health</span><span>/</span>
-                        <!---->
-                        <span
-                                data-bind="text: Battle.enemyPokemon().maxHealth">maxHealth</span>
                     </div>
 
                     <!--If the player is in a dungeon-->
                     <div data-bind="if: Game.gameState() === GameConstants.GameState.dungeon">
-                        <div class="col-lg-12" style="display: block; height: 170px">
+                        <div class="col-lg-12" style="display: block; height: 220px">
                             <div>
                                 <span data-bind="text: DungeonRunner.dungeon.name()">Dungeon name</span>
                                 <!--If all Pokémon on the route are caught-->
@@ -267,17 +269,22 @@
                                          src="assets/images/pokeball/Pokeball-shiny-small.png"/>
                                 </span>
 
-                                <br>
-                                <div style="height: 96px;">
+                                <div>
                                     <div data-bind="ifnot: DungeonBattle.catching">
                                         <img id="dungeonEnemy"
                                              data-bind="click: function() {DungeonBattle.clickAttack()}, attr:{ src: PokemonHelper.getImage(DungeonBattle.enemyPokemon(), DungeonBattle.enemyPokemon().shiny) }"
                                              src=""/>
+                                        <br>
+                                        <span data-bind="text: DungeonBattle.enemyPokemon().health">health</span>/
+                                        <span data-bind="text: DungeonBattle.enemyPokemon().maxHealth">maxHealth</span>
                                     </div>
                                     <div data-bind="if: DungeonBattle.catching">
                                         <img class="pokeball-animated"
                                              data-bind="attr:{ src: '/assets/images/pokeball/' + GameConstants.Pokeball[DungeonBattle.pokeball()] + '.png' }"
                                              src=""/>
+                                        <br>
+                                        Catch Chance: 
+                                        <span data-bind="text: DungeonBattle.enemyPokemon().catchRate">Catch Rate</span>%
                                     </div>
                                 </div>
                                 <div class="progress">
@@ -299,15 +306,6 @@
                                     Bossfight
                                 </button>
                             </div>
-                        </div>
-                        <div data-bind="if: DungeonRunner.fighting()">
-                            <div style="height: 30px">
-                                <span data-bind="text: DungeonBattle.enemyPokemon().health">health</span>/<span
-                                    data-bind="text: DungeonBattle.enemyPokemon().maxHealth">maxHealth</span>
-                            </div>
-                        </div>
-                        <div data-bind="ifnot: DungeonRunner.fighting()">
-                            <div style="height: 30px"></div>
                         </div>
                     </div>
                     <div data-bind="ifnot: Game.gameState() === GameConstants.GameState.town">

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -350,6 +350,10 @@ namespace GameConstants {
         return Math.floor(Math.random() * (max - min + 1)) + min;
     }
 
+    export function clipNumber(num: number, min: number, max: number) {
+        return Math.min(Math.max(num, min), max);
+    }
+
     export enum Badge {
         "None" = 0,
         "Boulder" = 1,

--- a/src/scripts/dungeons/DungeonBattle.ts
+++ b/src/scripts/dungeons/DungeonBattle.ts
@@ -17,11 +17,10 @@ class DungeonBattle extends Battle {
         let pokeBall: GameConstants.Pokeball = player.calculatePokeballToUse(alreadyCaught);
 
         if (pokeBall !== GameConstants.Pokeball.None) {
-            DungeonBattle.pokeball = ko.observable(pokeBall);
-            DungeonBattle.catching(true);
+            this.prepareCatch(pokeBall);
             setTimeout(
                 () => {
-                    this.throwPokeball(pokeBall);
+                    this.attemptCatch();
                     if (DungeonRunner.fightingBoss()) {
                         DungeonRunner.fightingBoss(false);
                         DungeonRunner.dungeonWon();

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -31,10 +31,7 @@ class PokemonFactory {
 
         // TODO this monster formula needs to be improved. Preferably with graphs :D
         let maxHealth: number = PokemonFactory.routeHealth(route);
-
-        let catchVariation = Math.floor(Math.random() * 7 - 3);
-
-        let catchRate: number = Math.floor(Math.pow(basePokemon.catchRate, 0.75)) + catchVariation;
+        let catchRate: number = this.catchRateHelper(basePokemon.catchRate);
         let exp: number = basePokemon.exp;
 
         let deviation = Math.floor(Math.random() * 51) - 25;
@@ -87,8 +84,7 @@ class PokemonFactory {
         let basePokemon = PokemonHelper.getPokemonByName(name);
         let id = basePokemon.id;
         let maxHealth: number = Math.floor(baseHealth * (1 + (chestsOpened / 5)));
-        let catchVariation = Math.floor(Math.random() * 7 - 3);
-        let catchRate: number = Math.floor(Math.pow(basePokemon.catchRate, 0.75)) + catchVariation;
+        let catchRate: number = this.catchRateHelper(basePokemon.catchRate);
         let exp: number = basePokemon.exp;
         let money: number = 0;
         let shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_BATTLE);
@@ -102,8 +98,7 @@ class PokemonFactory {
         let basePokemon = PokemonHelper.getPokemonByName(name);
         let id = basePokemon.id;
         let maxHealth: number = Math.floor(bossPokemon.baseHealth * (1 + (chestsOpened / 5)));
-        let catchVariation = Math.floor(Math.random() * 7 - 3);
-        let catchRate: number = Math.floor(Math.pow(basePokemon.catchRate, 0.75)) + catchVariation;
+        let catchRate: number = this.catchRateHelper(basePokemon.catchRate);
         let exp: number = basePokemon.exp;
         let money: number = 0;
         let shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_BATTLE);
@@ -125,4 +120,9 @@ class PokemonFactory {
         return Math.random() < 1 / (max + ( (min - max) * (maxRoute - curRoute) / (maxRoute - minRoute)));
     }
 
+    private static catchRateHelper(baseCatchRate: number) {
+        let catchVariation = GameConstants.randomIntBetween(-3, 3);
+        let catchRateRaw = Math.floor(Math.pow(baseCatchRate, 0.75)) + catchVariation;
+        return GameConstants.clipNumber(catchRateRaw, 0, 100);
+    }
 }


### PR DESCRIPTION
There used to be no catch rate display. I am adding it into route and dungeons.

I moved the health text above health bar. And when the pokemon is defeated, the catch chance display overwrites the health text.

**Examples:**
**Before catching:**
![image](https://user-images.githubusercontent.com/36806183/54658049-10e34d00-4aa2-11e9-9506-1f2cb5a7f826.png)
---------------------------------------------------------------------

**While catching:**
![image](https://user-images.githubusercontent.com/36806183/54658057-1c367880-4aa2-11e9-88bd-ac5c259aed07.png)
---------------------------------------------------------------------

**Dungeons:**
![image](https://user-images.githubusercontent.com/36806183/54658080-32443900-4aa2-11e9-927c-e881ee1f6cbe.png)
---------------------------------------------------------------------

**Also because I moved HP text above HP bar, I made it consistent with Gyms as well:**
![image](https://user-images.githubusercontent.com/36806183/54658116-530c8e80-4aa2-11e9-9816-64efad502be4.png)
