### PR TITLE
Evo stone fix

### DIFF
--- a/src/components/itemModal.html
+++ b/src/components/itemModal.html
@@ -63,19 +63,19 @@
                                      data-bind="foreach: PokemonHelper.getPokemonsWithEvolution(ItemHandler.stoneSelected())">
                                     <div class="col-md-6 col-sm-10 col-lg-4 offset-sm-1 offset-md-0 offset-md-0 breedingListItem" 
                                         data-bind="if: (player.alreadyCaughtPokemon($data.name))">
-                                        <button class="btn btn-secondary smallButton list-group-item-action"
+                                        <button class="btn btn-secondary smallButton list-group-item-action" style="padding-right:15px"
                                                 data-bind="click: function() {ItemHandler.pokemonSelected(name)}, css:{ 'pokemon-selected': ItemHandler.pokemonSelected() === name}">
                                             <img class="smallImage"
                                                  data-bind="attr:{ src: '/assets/images/pokemon/' + id +'.png' }"
                                                  src=""/>
                                             <span data-bind="text: name" style="margin-left: 20px">Name</span>
 
-                                            <span style="float:right; margin-right: 10px; margin-top: 8px" 
+                                            <span style="float:right; margin-top:8px"
                                                 data-bind="if: player.alreadyCaughtPokemonShiny(EvolutionStone.computeEvolution(
                                                 GameConstants.StoneType[ItemHandler.stoneSelected()], name))">
                                                 <img class="pokeball-smallest" src="assets/images/pokeball/Pokeball-shiny-small.png"/>
                                             </span>
-                                            <span style="float:right; margin-right: 10px; margin-top: 8px" 
+                                            <span style="float:right; margin-top:8px"
                                                 data-bind="if: (player.alreadyCaughtPokemon(EvolutionStone.computeEvolution(
                                                 GameConstants.StoneType[ItemHandler.stoneSelected()], name)) 
                                                 && !player.alreadyCaughtPokemonShiny(EvolutionStone.computeEvolution(

--- a/src/components/itemModal.html
+++ b/src/components/itemModal.html
@@ -61,15 +61,29 @@
                                 <div class="row col-lg-10 col-md-12 offset-md-0 col-sm-12 offset-sm-0"
                                      style="padding-right: 0"
                                      data-bind="foreach: PokemonHelper.getPokemonsWithEvolution(ItemHandler.stoneSelected())">
-                                    <div class="col-md-6 col-sm-10 col-lg-4 offset-sm-1 offset-md-0 offset-md-0 breedingListItem">
-
+                                    <div class="col-md-6 col-sm-10 col-lg-4 offset-sm-1 offset-md-0 offset-md-0 breedingListItem" 
+                                        data-bind="if: (player.alreadyCaughtPokemon($data.name))">
                                         <button class="btn btn-secondary smallButton list-group-item-action"
                                                 data-bind="click: function() {ItemHandler.pokemonSelected(name)}, css:{ 'pokemon-selected': ItemHandler.pokemonSelected() === name}">
                                             <img class="smallImage"
                                                  data-bind="attr:{ src: '/assets/images/pokemon/' + id +'.png' }"
                                                  src=""/>
                                             <span data-bind="text: name" style="margin-left: 20px">Name</span>
+
+                                            <span style="float:right; margin-right: 10px; margin-top: 8px" 
+                                                data-bind="if: player.alreadyCaughtPokemonShiny(EvolutionStone.computeEvolution(
+                                                GameConstants.StoneType[ItemHandler.stoneSelected()], name))">
+                                                <img class="pokeball-smallest" src="assets/images/pokeball/Pokeball-shiny-small.png"/>
+                                            </span>
+                                            <span style="float:right; margin-right: 10px; margin-top: 8px" 
+                                                data-bind="if: (player.alreadyCaughtPokemon(EvolutionStone.computeEvolution(
+                                                GameConstants.StoneType[ItemHandler.stoneSelected()], name)) 
+                                                && !player.alreadyCaughtPokemonShiny(EvolutionStone.computeEvolution(
+                                                    GameConstants.StoneType[ItemHandler.stoneSelected()], name)))">
+                                                <img class="pokeball-smallest" src="assets/images/pokeball/Pokeball-small.png"/>
+                                            </span>
                                         </button>
+
                                     </div>
                                 </div>
                             </div>

--- a/src/scripts/items/EvolutionStone.ts
+++ b/src/scripts/items/EvolutionStone.ts
@@ -22,31 +22,10 @@ class EvolutionStone extends Item {
     }
 
     public static computeEvolution(type: GameConstants.StoneType, pokemon: string): string {
-        if (pokemon == "Eevee") {
-            switch (type) {
-                case GameConstants.StoneType.Fire_stone: {
-                    return "Flareon";
-                }
-                case GameConstants.StoneType.Water_stone: {
-                    return "Vaporeon";
-                }
-                case GameConstants.StoneType.Thunder_stone: {
-                    return "Jolteon";
-                }
-            }
-        } else if (pokemon == "Gloom") {
-            switch (type) {
-                case GameConstants.StoneType.Leaf_stone: {
-                    return "Vileplume";
-                }
-                case GameConstants.StoneType.Sun_stone: {
-                    return "Bellossom";
-                }
-            }
-        }
-        else {
-            return PokemonHelper.getPokemonByName(pokemon).evolution;
-        }
+        // Assume stones and evolutions in pokemonList are consistent in ordering
+        let pkmObj = PokemonHelper.getPokemonByName(pokemon);
+        let index = ("" + pkmObj.evoLevel).split(", ").indexOf(GameConstants.StoneType[type]);
+        return pkmObj.evolution.split(", ")[index];
     }
 }
 

--- a/src/scripts/items/EvolutionStone.ts
+++ b/src/scripts/items/EvolutionStone.ts
@@ -14,33 +14,31 @@ class EvolutionStone extends Item {
         player.gainItem(GameConstants.StoneType[this.type], n)
     }
 
-
-
     public use(pokemon?:string) {
         let shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_STONE);
+        let evolution = EvolutionStone.computeEvolution(this.type, pokemon);
+        player.capturePokemon(evolution, shiny, false);
+        return shiny;
+    }
+
+    public static computeEvolution(type: GameConstants.StoneType, pokemon: string): string {
         if(pokemon == "Eevee") {
-            switch (this.type) {
+            switch (type) {
                 case GameConstants.StoneType.Fire_stone: {
-                    player.capturePokemon("Flareon", shiny, false);
-                    break;
+                    return "Flareon";
                 }
                 case GameConstants.StoneType.Water_stone: {
-                    player.capturePokemon("Vaporeon", shiny, false);
-                    break;
+                    return "Vaporeon";
                 }
                 case GameConstants.StoneType.Thunder_stone: {
-                    player.capturePokemon("Jolteon", shiny, false);
-                    break;
+                    return "Jolteon";
                 }
             }
         }
         else {
-            let evolution: string = PokemonHelper.getPokemonByName(pokemon).evolution;
-            player.capturePokemon(evolution, shiny, false);
+            return PokemonHelper.getPokemonByName(pokemon).evolution;
         }
-        return shiny;
     }
-
 }
 
 ItemList['Fire_stone'] = new EvolutionStone(GameConstants.StoneType.Fire_stone);

--- a/src/scripts/items/EvolutionStone.ts
+++ b/src/scripts/items/EvolutionStone.ts
@@ -22,7 +22,7 @@ class EvolutionStone extends Item {
     }
 
     public static computeEvolution(type: GameConstants.StoneType, pokemon: string): string {
-        if(pokemon == "Eevee") {
+        if (pokemon == "Eevee") {
             switch (type) {
                 case GameConstants.StoneType.Fire_stone: {
                     return "Flareon";
@@ -32,6 +32,15 @@ class EvolutionStone extends Item {
                 }
                 case GameConstants.StoneType.Thunder_stone: {
                     return "Jolteon";
+                }
+            }
+        } else if (pokemon == "Gloom") {
+            switch (type) {
+                case GameConstants.StoneType.Leaf_stone: {
+                    return "Vileplume";
+                }
+                case GameConstants.StoneType.Sun_stone: {
+                    return "Bellossom";
                 }
             }
         }

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -1795,7 +1795,7 @@ const pokemonList = [
         "name": "Eevee",
         "catchRate": 45,
         "evolution": "Vaporeon, Jolteon, Flareon, Espeon, Umbreon",
-        "evoLevel": "Water Stone, Thunder Stone, Fire Stone, Time Stone, Time Stone",
+        "evoLevel": "Water_stone, Thunder_stone, Fire_stone, Time Stone, Time Stone",
         "type": [
             "Normal"
         ],

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -602,7 +602,7 @@ const pokemonList = [
         "id": 44,
         "name": "Gloom",
         "catchRate": 120,
-        "evolution": "Vileplume, ",
+        "evolution": "Vileplume, Bellossom",
         "evoLevel": "Leaf_stone, Sun_stone",
         "type": [
             "Grass",

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -1795,7 +1795,7 @@ const pokemonList = [
         "name": "Eevee",
         "catchRate": 45,
         "evolution": "Vaporeon, Jolteon, Flareon, Espeon, Umbreon",
-        "evoLevel": "Water_stone, Thunder_stone, Fire_stone, Time Stone, Time Stone",
+        "evoLevel": "Water_stone, Thunder_stone, Fire_stone, Time_stone, Time_stone",
         "type": [
             "Normal"
         ],

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -602,8 +602,8 @@ const pokemonList = [
         "id": 44,
         "name": "Gloom",
         "catchRate": 120,
-        "evolution": "Vileplume, Bellossom",
-        "evoLevel": "Leaf Stone, Sun Stone",
+        "evolution": "Vileplume, ",
+        "evoLevel": "Leaf_stone, Sun_stone",
         "type": [
             "Grass",
             "Poison"


### PR DESCRIPTION
The evolution stone menu had three issues:

1. Major issue: it's showing all base form Pokemon that can evolve using said stone, including those that the player doesn't have.
2. Major issue: Eevee evolutions were not coded correctly.
3. It doesn't have any indicator for if the player already has the evolved form (caught or shiny).

What this change looks like:

I do not have Exeggcute, so it doesn't show up for Grass Stone:

![image](https://user-images.githubusercontent.com/36806183/54797297-e6bc9700-4c29-11e9-9762-6004bf80ba6f.png)


Correctly shows which evolved form I have and not have, and whether I have them shiny. Eevee evolutions also appear correctly now.

![image](https://user-images.githubusercontent.com/36806183/54797323-08b61980-4c2a-11e9-8da9-d740068f1e8c.png)

If you look closely, you'll see that the regular pokeball is a bit farther from the right than the shiny pokeball. This is something I was not successful at addressing. I feel it's a minor issue that can be put into backlog.