### PR TITLE
Make mobile play easier, Disable zoom.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,8 @@
 <head>
     <title>Pokeclicker</title>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+
     <!--jQuery-->
     <script src="libs/jquery.min.js"></script>
 


### PR DESCRIPTION
## Current Behavior:
When tapping fast the page will zoom in and out constantly
## Improved Behavior:
When tapping fast, will no longer zoom, instead it will just count as standard clicks
## Reason for change:
Makes mobile play a ton easier/possible,
In the current state it is near impossible to beat some stages without major grinding before hand

***Note:*** I've done this on the master branch as it would be great if we could patch the current version