### PR TITLE
Show items remaining, Use items, Buy items

### DIFF
--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -1,29 +1,22 @@
 <div class="page-item" id="battleItemContainer">
     <div class="card">
-        <div class="row justify-content-sm-center">
+        <div class="row justify-content-sm-center"
+            data-bind="foreach: Object.keys(ItemList).filter(i=>ItemList[i].constructor.name == 'BattleItem')">
             <div class="battle-item-small">
-                <img src="assets/images/items/xAttack.png" class="clickable" onclick="ItemHandler.useItem('xAttack')">
-                <div class="meter" id="xAttack-meter"></div>
-            </div>
-            <div class="battle-item-small">
-                <img src="assets/images/items/xClick.png" class="clickable" onclick="ItemHandler.useItem('xClick')">
-                <div class="meter" id="xClick-meter"></div>
-            </div>
-            <div class="battle-item-small">
-                <img src="assets/images/items/xExp.png" class="clickable" onclick="ItemHandler.useItem('xExp')">
-                <div class="meter" id="xExp-meter"></div>
-            </div>
-            <div class="battle-item-small">
-                <img src="assets/images/items/Lucky_incense.png" class="clickable" onclick="ItemHandler.useItem('Lucky_incense')">
-                <div class="meter" id="Lucky_incense-meter"></div>
-            </div>
-            <div class="battle-item-small">
-                <img src="assets/images/items/Token_collector.png" class="clickable" onclick="ItemHandler.useItem('Token_collector')">
-                <div class="meter" id="Token_collector-meter"></div>
-            </div>
-            <div class="battle-item-small">
-                <img src="assets/images/items/Item_magnet.png" class="clickable" onclick="ItemHandler.useItem('Item_magnet')">
-                <div class="meter" id="Item_magnet-meter"></div>
+                <img src="" class="clickable"
+                data-bind="attr:{ src: '/assets/images/items/' + $data + '.png'},
+                            css: {
+                                'battle-item-none': !(+player.itemList[$data]())
+                            },
+                            event: {
+                                click: function(){ItemHandler.useItem($data)}
+                            },
+                            tooltip: {
+                                title: $data.replace(/_/g, ' ') + ' remaining: ' + (+player.itemList[$data]()),
+                                trigger: 'hover',
+                                placement: 'top',
+                            }">
+                <div class="meter" data-bind="attr: {id:$data + '-meter'}"></div>
             </div>
         </div>
 

--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -12,7 +12,7 @@
                                 click: function(){ItemHandler.useItem($data)}
                             },
                             tooltip: {
-                                title: $data.replace(/_/g, ' ') + ' remaining: ' + (+player.itemList[$data]()),
+                                title: ko.pureComputed(function(){return $data.replace(/_/g, ' ') + ' remaining: ' + (+player.itemList[$data]())}),
                                 trigger: 'hover',
                                 placement: 'top',
                             }">

--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -2,27 +2,27 @@
     <div class="card">
         <div class="row justify-content-sm-center">
             <div class="battle-item-small">
-                <img src="assets/images/items/xAttack.png">
+                <img src="assets/images/items/xAttack.png" class="clickable" onclick="ItemHandler.useItem('xAttack')">
                 <div class="meter" id="xAttack-meter"></div>
             </div>
             <div class="battle-item-small">
-                <img src="assets/images/items/xClick.png">
+                <img src="assets/images/items/xClick.png" class="clickable" onclick="ItemHandler.useItem('xClick')">
                 <div class="meter" id="xClick-meter"></div>
             </div>
             <div class="battle-item-small">
-                <img src="assets/images/items/xExp.png">
+                <img src="assets/images/items/xExp.png" class="clickable" onclick="ItemHandler.useItem('xExp')">
                 <div class="meter" id="xExp-meter"></div>
             </div>
             <div class="battle-item-small">
-                <img src="assets/images/items/Lucky_incense.png">
+                <img src="assets/images/items/Lucky_incense.png" class="clickable" onclick="ItemHandler.useItem('Lucky_incense')">
                 <div class="meter" id="Lucky_incense-meter"></div>
             </div>
             <div class="battle-item-small">
-                <img src="assets/images/items/Token_collector.png">
+                <img src="assets/images/items/Token_collector.png" class="clickable" onclick="ItemHandler.useItem('Token_collector')">
                 <div class="meter" id="Token_collector-meter"></div>
             </div>
             <div class="battle-item-small">
-                <img src="assets/images/items/Item_magnet.png">
+                <img src="assets/images/items/Item_magnet.png" class="clickable" onclick="ItemHandler.useItem('Item_magnet')">
                 <div class="meter" id="Item_magnet-meter"></div>
             </div>
         </div>

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -36,7 +36,7 @@ class Player {
     private _oakItemsEquipped: string[];
     private _eggList: Array<KnockoutObservable<Egg | void>>;
     private _eggSlots: KnockoutObservable<number>;
-    private _effectEngine: string[];
+    private _effectEngine: { [name: string]: number };
 
     constructor(savedPlayer?) {
         let saved: boolean = (savedPlayer != null);
@@ -84,7 +84,7 @@ class Player {
             return ko.observable(savedPlayer._oakItemExp ? (savedPlayer._oakItemExp[index] || 0) : 0)
         });
         this._oakItemsEquipped = savedPlayer._oakItemsEquipped || [];
-        this._effectEngine = savedPlayer._effectEngine || [];
+        this._effectEngine = savedPlayer._effectEngine || {};
         this._routeKillsNeeded = ko.observable(savedPlayer._routeKillsNeeded || 10);
         this._gymBadges = ko.observableArray<GameConstants.Badge>(savedPlayer._gymBadges);
         this._keyItems = ko.observableArray<string>(savedPlayer._keyItems);
@@ -732,11 +732,11 @@ class Player {
         this._oakItemsEquipped = value;
     }
 
-    get effectEngine(): string[] {
+    get effectEngine(): { [name: string]: number } {
         return this._effectEngine;
     }
 
-    set effectEngine(value: string[]) {
+    set effectEngine(value: { [name: string]: number }) {
         this._effectEngine = value;
     }
 

--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -5,12 +5,10 @@ class effectEngineRunner {
         this.counter = 0;
         
         for(let item in player.effectEngine){
-            if(item != 'equals'){
-                player.effectEngine[item] -= 1;
-                let newWidth = player.effectEngine[item] / parseInt($('#'+item+'-meter').attr('maxTime')) * 100;
-                $('#'+item+'-meter').css('width',newWidth + "%");
-                $('#'+item+'-meter').parent().attr('title','Seconds Remaining: ' + player.effectEngine[item] );
-            }
+            player.effectEngine[item] -= 1;
+            const newWidth = player.effectEngine[item] / parseInt($('#'+item+'-meter').attr('maxTime')) * 100;
+            $('#'+item+'-meter').css('width', newWidth + "%");
+            $('#'+item+'-meter').parent().attr('title', 'Seconds Remaining: ' + player.effectEngine[item] );
             if(player.effectEngine[item] <= 0){
                 delete player.effectEngine[item];
                 $('#'+item+'-meter').parent().removeAttr('title');
@@ -20,7 +18,7 @@ class effectEngineRunner {
     }
 
     public static addEffect(itemName: string){
-        player.effectEngine[itemName] = (player.effectEngine[itemName] ? player.effectEngine[itemName]: 0) + GameConstants.ITEM_USE_TIME;
+        player.effectEngine[itemName] = (player.effectEngine[itemName] ? player.effectEngine[itemName] : 0) + GameConstants.ITEM_USE_TIME;
         $('#'+itemName+'-meter').css('width','100%');
         $('#'+itemName+'-meter').attr('maxTime',player.effectEngine[itemName]);
     }

--- a/src/scripts/items/BattleItem.ts
+++ b/src/scripts/items/BattleItem.ts
@@ -33,10 +33,11 @@ class BattleItem extends Item {
     }
 
     buy(amt: number) {
+        player.gainItem(this.name(), amt);
     }
 
     use() {
-        effectEngineRunner.addEffect(this.name());        
+        effectEngineRunner.addEffect(this.name());
     }
 }
 

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -5,9 +5,12 @@ class ItemHandler {
     public static amountSelected: KnockoutObservable<number> = ko.observable(1);
     static amount: KnockoutObservable<number> = ko.observable(1);
 
-    public static useItem(name:string){
-        ItemList[name].use();
-        player.itemList[name](player.itemList[name]-1);
+    public static useItem(name: string){
+        if (!player.itemList[name]())
+          return Notifier.notify(`You don't have any ${name.replace(/_/g, ' ')}s left...`, GameConstants.NotificationOption.danger);
+
+        player.itemList[name](player.itemList[name]()-1);
+        return ItemList[name].use();
     }
 
     public static resetAmount() {

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -1,7 +1,7 @@
 class ItemHandler {
 
     public static stoneSelected: KnockoutObservable<string> = ko.observable("Fire_stone");
-    public static pokemonSelected: KnockoutObservable<string> = ko.observable("");
+    public static pokemonSelected: KnockoutObservable<string> = ko.observable("Vulpix");
     public static amountSelected: KnockoutObservable<number> = ko.observable(1);
     static amount: KnockoutObservable<number> = ko.observable(1);
 

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -23,14 +23,12 @@ class ItemHandler {
 
     public static useStones(){
         if(this.pokemonSelected() == ""){
-            Notifier.notify("No Pokémon selected", GameConstants.NotificationOption.danger);
-            return;
+            return Notifier.notify("No Pokémon selected", GameConstants.NotificationOption.danger);
         }
         let amount = Math.min(this.amountSelected(), player.itemList[this.stoneSelected()]());
 
-        if(amount == 0){
-            Notifier.notify("You don't have any stones left...", GameConstants.NotificationOption.danger);
-            return;
+        if(!amount){
+            return Notifier.notify(`You don't have any ${this.stoneSelected().replace(/_/g, ' ')}s left...`, GameConstants.NotificationOption.danger);
         }
 
         for(let i = 0; i< amount; i++){

--- a/src/styles/battleItem.less
+++ b/src/styles/battleItem.less
@@ -12,6 +12,11 @@
   border: 1px solid #ff2f39;
 }
 
+.battle-item-none {
+  filter: brightness(0.8);
+  opacity: 0.4;
+}
+
 .meter {
   width:0%;
   background-color:rgb(58, 255, 58);


### PR DESCRIPTION
- [x] Update the items `buy` method to increase the item amount
- [x] Use on click
- [x] Show error notification if no items remaining (also say which item is out)
- [x] Show which stone you have none of in the error notification
- [x] Fix `useItem` method:
  - [x] check the player has any before allowing them to use it
  - [x] deduct 1 from the current amount they have
- [x] Change `effectEngine` to `{}` ([refer here](https://github.com/Ishadijcks/pokeclicker/pull/272/files#r210209855))
  - You may need to manually update `player.effectEngine = {}` if you have loaded this object previously, as it will be set to `[]`

***Note:***
this is being merged into the `display-items` branch, to be merged into the `develop` branch with #272 

closes #134