### PR TITLE
Show current shiny Pokemon in the breeding list, Update hatch button alignment

### DIFF
--- a/src/components/breeding.html
+++ b/src/components/breeding.html
@@ -24,7 +24,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                     data-bind="foreach: player.maxLevelPokemonList()">
                    <div class="col-md-6 col-sm-10 col-lg-4 offset-sm-1 offset-md-0 offset-md-0 breedingListItem">
                        <button class="btn btn-secondary smallButton list-group-item-action"
-                               data-bind="click: function() {BreedingHelper.gainPokemonEgg($data)}">
+                               data-bind="click: function() {$('#breedingModal').modal('hide');BreedingHelper.gainPokemonEgg($data);}">
                            <img class="smallImage"
                                 data-bind="attr:{ src: '/assets/images/' + (player.caughtShinyList().includes(name) ? 'shiny' : '') + 'pokemon/' + id +'.png' }"
                                 src=""/>

--- a/src/components/breeding.html
+++ b/src/components/breeding.html
@@ -28,7 +28,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                            <img class="smallImage"
                                 data-bind="attr:{ src: '/assets/images/' + (player.caughtShinyList().includes(name) ? 'shiny' : '') + 'pokemon/' + id +'.png' }"
                                 src=""/>
-                           <span data-bind="text: name" style="margin-left: 20px">Name</span><span data-bind="if: player.caughtShinyList().includes(name)">&nbsp;✨</span>
+                           <span data-bind="text: name" style="margin-left: 20px">Name</span><span style="float:right" data-bind="if: player.caughtShinyList().includes(name)">&nbsp;✨</span>
                        </button>
                    </div>
                </div>

--- a/src/components/breeding.html
+++ b/src/components/breeding.html
@@ -26,9 +26,9 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                        <button class="btn btn-secondary smallButton list-group-item-action"
                                data-bind="click: function() {BreedingHelper.gainPokemonEgg($data)}">
                            <img class="smallImage"
-                                data-bind="attr:{ src: '/assets/images/' + (player._caughtShinyList().includes(name) ? 'shiny' : '') + 'pokemon/' + id +'.png' }"
+                                data-bind="attr:{ src: '/assets/images/' + (player.caughtShinyList().includes(name) ? 'shiny' : '') + 'pokemon/' + id +'.png' }"
                                 src=""/>
-                           <span data-bind="text: name" style="margin-left: 20px">Name</span>
+                           <span data-bind="text: name" style="margin-left: 20px">Name</span><span data-bind="if: player.caughtShinyList().includes(name)">&nbsp;✨</span>
                        </button>
                    </div>
                </div>

--- a/src/components/breeding.html
+++ b/src/components/breeding.html
@@ -26,7 +26,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                        <button class="btn btn-secondary smallButton list-group-item-action"
                                data-bind="click: function() {BreedingHelper.gainPokemonEgg($data)}">
                            <img class="smallImage"
-                                data-bind="attr:{ src: '/assets/images/pokemon/' + id +'.png' }"
+                                data-bind="attr:{ src: '/assets/images/' + (player._caughtShinyList().includes(name) ? 'shiny' : '') + 'pokemon/' + id +'.png' }"
                                 src=""/>
                            <span data-bind="text: name" style="margin-left: 20px">Name</span>
                        </button>

--- a/src/components/breedingDisplay.html
+++ b/src/components/breedingDisplay.html
@@ -21,11 +21,11 @@
                              aria-valuemin="0" aria-valuemax="100">
                         </div>
                     </div>
-                    <div data-bind='if: progress() >= 100'>
-                        <button class='btn btn-primary'
-                                data-bind='click: function(){BreedingHelper.hatchPokemonEgg($index())}'>
-                            Hatch!
-                        </button>
+                    <div class="progress" data-bind='if: progress() >= 100'>
+                        <div class="progress-bar bg-blue" role="progressbar"
+                        data-bind="attr:{ style: 'width: 100%; cursor: pointer;' }, click: function(){BreedingHelper.hatchPokemonEgg($index())}, text: 'Hatch!'"
+                        aria-valuemin="0" aria-valuemax="100">
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/breedingDisplay.html
+++ b/src/components/breedingDisplay.html
@@ -17,7 +17,7 @@
                     <div class="progress" data-bind='if: progress() < 100,
                                                          tooltip: {title: ko.pureComputed(function(){return Math.floor(progress()) + "%"}), trigger: "hover"}'>
                         <div class="progress-bar bg-success" role="progressbar"
-                             data-bind="attr:{ style: 'width:' + $data.progress() + '%' }"
+                             data-bind="attr:{ style: 'width:' + $data.progress() + '%' }, text: Math.floor($data.progress()) + '%'"
                              aria-valuemin="0" aria-valuemax="100">
                         </div>
                     </div>

--- a/src/components/breedingDisplay.html
+++ b/src/components/breedingDisplay.html
@@ -8,7 +8,7 @@
                     <button class='btn btn-primary' onclick='player.buyEggSlot()'
                             data-bind='css: {disabled: player.questPoints <= player.nextEggSlotCost()}'>Buy</button>
                 </div>
-                <div data-bind="if: $index() > player.eggSlots()" style="margin-top:44px;">
+                <div data-bind="if: $index() > player.eggSlots()" style="margin-top: 30px;">
                     <img src="../assets/images/breeding/lock.png">
                 </div>
                 <div data-bind="if: $data !== null">

--- a/src/components/breedingDisplay.html
+++ b/src/components/breedingDisplay.html
@@ -14,11 +14,11 @@
                 <div data-bind="if: $data !== null">
                     <img data-bind='attr: {src: BreedingHelper.getEggImage($data)}'/>
 
-                    <div class="progress" data-bind='if: progress() < 100,
-                                                         tooltip: {title: ko.pureComputed(function(){return Math.floor(progress()) + "%"}), trigger: "hover"}'>
+                    <div class="progress" data-bind='if: progress() < 100'>
                         <div class="progress-bar bg-success" role="progressbar"
-                             data-bind="attr:{ style: 'width:' + $data.progress() + '%' }, text: Math.floor($data.progress()) + '%'"
+                             data-bind="attr:{ style: 'width:' + $data.progress() + '%' }"
                              aria-valuemin="0" aria-valuemax="100">
+							 <span data-bind="text: Math.floor($data.progress()) + '%'"></span>
                         </div>
                     </div>
                     <div class="progress" data-bind='if: progress() >= 100'>

--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -46,9 +46,6 @@ class BreedingHelper {
         pokemon.breeding(true);
         player.gainEgg(egg);
         pokemon.attackBonus(pokemon.attackBonus() + GameConstants.BREEDING_ATTACK_BONUS);
-
-        $('#breedingModal').modal('hide');
-
     }
 
     public static hatchPokemonEgg(index: number) {

--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -13,8 +13,8 @@ class BreedingHelper {
     }
 
     public static progressEggs(amount: number) {
-        if (OakItemRunner.isActive("Blaze Casette")) {
-            amount *= (1 + OakItemRunner.calculateBonus("Blaze Casette") / 100)
+        if (OakItemRunner.isActive("Blaze Cassette")) {
+            amount *= (1 + OakItemRunner.calculateBonus("Blaze Cassette") / 100)
         }
         amount = Math.round(amount);
         for (let obj of player.eggList) {
@@ -64,6 +64,7 @@ class BreedingHelper {
         player.capturePokemon(egg.pokemon, shiny);
         player._eggList[index](null);
         GameHelper.incrementObservable(player.statistics.hatchedEggs);
+        OakItemRunner.use("Blaze Cassette");
     }
 
     public static createEgg(pokemonName: string, type = GameConstants.EggType.Pokemon): Egg {

--- a/src/styles/breeding.less
+++ b/src/styles/breeding.less
@@ -18,7 +18,7 @@
   .progress {
     width: 80%;
     background-color: #ddd;
-    margin: 5px auto 0 auto;
+    margin: 0px auto 0 auto;
   }
 }
 

--- a/src/styles/breeding.less
+++ b/src/styles/breeding.less
@@ -19,6 +19,12 @@
     width: 80%;
     background-color: #ddd;
     margin: 0px auto 0 auto;
+    span {
+      position: absolute;
+      display: block;
+      width: 80%;
+      color: black;
+    }
   }
 }
 


### PR DESCRIPTION
This PR will show the shiny sprite in the breeding list, and also adds a sparkle emoji next to the name.
_note that the sparkle icon will look slightly different between different browsers_
![image](https://user-images.githubusercontent.com/7288322/58293527-db4c3e80-7e19-11e9-920c-6143fc970156.png)
![image](https://user-images.githubusercontent.com/7288322/58293605-531a6900-7e1a-11e9-9d11-73a726b27cc7.png)
![image](https://user-images.githubusercontent.com/7288322/58296284-38022600-7e27-11e9-96d9-9608330ebca6.png)

Fixed the alignment of the Hatch button and progress bars:
Added progress text to the progress bar
![image](https://user-images.githubusercontent.com/7288322/58292593-092f8400-7e16-11e9-9fbd-3e1d32c075cd.png)
