### PR TITLE
Fix Johto & Hoenn Pokemon evolving

### DIFF
--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -2040,1327 +2040,1327 @@ const pokemonList = [
         "eggCycles": 120
     },
     {
-      "id": "152",
+      "id": 152,
       "name": "Chikorita",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Bayleef",
-      "evoLevel": "16",
+      "evoLevel": 16,
       "type": [
         "Grass"
       ],
-      "attack": "65",
+      "attack": 65,
       "levelType": "mediumslow",
-      "exp": "64",
-      "eggCycles": "20"
+      "exp": 64,
+      "eggCycles": 20
     },
     {
-      "id": "153",
+      "id": 153,
       "name": "Bayleef",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Meganium",
-      "evoLevel": "32",
+      "evoLevel": 32,
       "type": [
         "Grass"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "mediumslow",
-      "exp": "142",
-      "eggCycles": "20"
+      "exp": 142,
+      "eggCycles": 20
     },
     {
-      "id": "154",
+      "id": 154,
       "name": "Meganium",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Grass"
       ],
-      "attack": "100",
+      "attack": 100,
       "levelType": "mediumslow",
-      "exp": "236",
-      "eggCycles": "20"
+      "exp": 236,
+      "eggCycles": 20
     },
     {
-      "id": "155",
+      "id": 155,
       "name": "Cyndaquil",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Quilava",
-      "evoLevel": "14",
+      "evoLevel": 14,
       "type": [
         "Fire"
       ],
-      "attack": "52",
+      "attack": 52,
       "levelType": "mediumslow",
-      "exp": "62",
-      "eggCycles": "20"
+      "exp": 62,
+      "eggCycles": 20
     },
     {
-      "id": "156",
+      "id": 156,
       "name": "Quilava",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Typhlosion",
-      "evoLevel": "36",
+      "evoLevel": 36,
       "type": [
         "Fire"
       ],
-      "attack": "65",
+      "attack": 65,
       "levelType": "mediumslow",
-      "exp": "142",
-      "eggCycles": "20"
+      "exp": 142,
+      "eggCycles": 20
     },
     {
-      "id": "157",
+      "id": 157,
       "name": "Typhlosion",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Fire"
       ],
-      "attack": "85",
+      "attack": 85,
       "levelType": "mediumslow",
-      "exp": "240",
-      "eggCycles": "20"
+      "exp": 240,
+      "eggCycles": 20
     },
     {
-      "id": "158",
+      "id": 158,
       "name": "Totodile",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Croconaw",
-      "evoLevel": "18",
+      "evoLevel": 18,
       "type": [
         "Water"
       ],
-      "attack": "65",
+      "attack": 65,
       "levelType": "mediumslow",
-      "exp": "63",
-      "eggCycles": "20"
+      "exp": 63,
+      "eggCycles": 20
     },
     {
-      "id": "159",
+      "id": 159,
       "name": "Croconaw",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Feraligatr",
-      "evoLevel": "30",
+      "evoLevel": 30,
       "type": [
         "Water"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "mediumslow",
-      "exp": "142",
-      "eggCycles": "20"
+      "exp": 142,
+      "eggCycles": 20
     },
     {
-      "id": "160",
+      "id": 160,
       "name": "Feraligatr",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Water"
       ],
-      "attack": "105",
+      "attack": 105,
       "levelType": "mediumslow",
-      "exp": "239",
-      "eggCycles": "20"
+      "exp": 239,
+      "eggCycles": 20
     },
     {
-      "id": "161",
+      "id": 161,
       "name": "Sentret",
-      "catchRate": "255",
+      "catchRate": 255,
       "evolution": "Furret",
-      "evoLevel": "15",
+      "evoLevel": 15,
       "type": [
         "Normal"
       ],
-      "attack": "46",
+      "attack": 46,
       "levelType": "mediumfast",
-      "exp": "43",
-      "eggCycles": "15"
+      "exp": 43,
+      "eggCycles": 15
     },
     {
-      "id": "162",
+      "id": 162,
       "name": "Furret",
-      "catchRate": "90",
+      "catchRate": 90,
       "type": [
         "Normal"
       ],
-      "attack": "76",
+      "attack": 76,
       "levelType": "mediumfast",
-      "exp": "145",
-      "eggCycles": "15"
+      "exp": 145,
+      "eggCycles": 15
     },
     {
-      "id": "163",
+      "id": 163,
       "name": "Hoothoot",
-      "catchRate": "255",
+      "catchRate": 255,
       "evolution": "Noctowl",
-      "evoLevel": "20",
+      "evoLevel": 20,
       "type": [
         "Normal",
         "Flying"
       ],
-      "attack": "56",
+      "attack": 56,
       "levelType": "mediumfast",
-      "exp": "52",
-      "eggCycles": "15"
+      "exp": 52,
+      "eggCycles": 15
     },
     {
-      "id": "164",
+      "id": 164,
       "name": "Noctowl",
-      "catchRate": "90",
+      "catchRate": 90,
       "type": [
         "Normal",
         "Flying"
       ],
-      "attack": "96",
+      "attack": 96,
       "levelType": "mediumfast",
-      "exp": "158",
-      "eggCycles": "15"
+      "exp": 158,
+      "eggCycles": 15
     },
     {
-      "id": "165",
+      "id": 165,
       "name": "Ledyba",
-      "catchRate": "255",
+      "catchRate": 255,
       "evolution": "Ledian",
-      "evoLevel": "18",
+      "evoLevel": 18,
       "type": [
         "Bug",
         "Flying"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "fast",
-      "exp": "53",
-      "eggCycles": "15"
+      "exp": 53,
+      "eggCycles": 15
     },
     {
-      "id": "166",
+      "id": 166,
       "name": "Ledian",
-      "catchRate": "90",
+      "catchRate": 90,
       "type": [
         "Bug",
         "Flying"
       ],
-      "attack": "110",
+      "attack": 110,
       "levelType": "fast",
-      "exp": "137",
-      "eggCycles": "15"
+      "exp": 137,
+      "eggCycles": 15
     },
     {
-      "id": "167",
+      "id": 167,
       "name": "Spinarak",
-      "catchRate": "255",
+      "catchRate": 255,
       "evolution": "Ariados",
-      "evoLevel": "22",
+      "evoLevel": 22,
       "type": [
         "Bug",
         "Poison"
       ],
-      "attack": "60",
+      "attack": 60,
       "levelType": "fast",
-      "exp": "50",
-      "eggCycles": "15"
+      "exp": 50,
+      "eggCycles": 15
     },
     {
-      "id": "168",
+      "id": 168,
       "name": "Ariados",
-      "catchRate": "90",
+      "catchRate": 90,
       "type": [
         "Bug",
         "Poison"
       ],
-      "attack": "90",
+      "attack": 90,
       "levelType": "fast",
-      "exp": "140",
-      "eggCycles": "15"
+      "exp": 140,
+      "eggCycles": 15
     },
     {
-      "id": "169",
+      "id": 169,
       "name": "Crobat",
-      "catchRate": "90",
+      "catchRate": 90,
       "type": [
         "Poison",
         "Flying"
       ],
-      "attack": "90",
+      "attack": 90,
       "levelType": "mediumfast",
-      "exp": "241",
-      "eggCycles": "15"
+      "exp": 241,
+      "eggCycles": 15
     },
     {
-      "id": "170",
+      "id": 170,
       "name": "Chinchou",
-      "catchRate": "190",
+      "catchRate": 190,
       "evolution": "Lanturn",
-      "evoLevel": "27",
+      "evoLevel": 27,
       "type": [
         "Water",
         "Electric"
       ],
-      "attack": "56",
+      "attack": 56,
       "levelType": "slow",
-      "exp": "66",
-      "eggCycles": "20"
+      "exp": 66,
+      "eggCycles": 20
     },
     {
-      "id": "171",
+      "id": 171,
       "name": "Lanturn",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Water",
         "Electric"
       ],
-      "attack": "76",
+      "attack": 76,
       "levelType": "slow",
-      "exp": "161",
-      "eggCycles": "20"
+      "exp": 161,
+      "eggCycles": 20
     },
     {
-      "id": "172",
+      "id": 172,
       "name": "Pichu",
-      "catchRate": "190",
+      "catchRate": 190,
       "evolution": "Pikachu",
       "evoLevel": 100,
       "type": [
         "Electric"
       ],
-      "attack": "40",
+      "attack": 40,
       "levelType": "mediumfast",
-      "exp": "41",
-      "eggCycles": "10"
+      "exp": 41,
+      "eggCycles": 10
     },
     {
-      "id": "173",
+      "id": 173,
       "name": "Cleffa",
-      "catchRate": "150",
+      "catchRate": 150,
       "evolution": "Clefairy",
       "evoLevel": 100,
       "type": [
         "Fairy"
       ],
-      "attack": "55",
+      "attack": 55,
       "levelType": "fast",
-      "exp": "44",
-      "eggCycles": "10"
+      "exp": 44,
+      "eggCycles": 10
     },
     {
-      "id": "174",
+      "id": 174,
       "name": "Igglybuff",
-      "catchRate": "170",
+      "catchRate": 170,
       "evolution": "Jigglypuff",
       "evoLevel": 100,
       "type": [
         "Normal",
         "Fairy"
       ],
-      "attack": "30",
+      "attack": 30,
       "levelType": "fast",
-      "exp": "42",
-      "eggCycles": "10"
+      "exp": 42,
+      "eggCycles": 10
     },
     {
-      "id": "175",
+      "id": 175,
       "name": "Togepi",
-      "catchRate": "190",
+      "catchRate": 190,
       "evolution": "Togetic",
       "evoLevel": 100,
       "type": [
         "Fairy"
       ],
-      "attack": "65",
+      "attack": 65,
       "levelType": "fast",
-      "exp": "49",
-      "eggCycles": "10"
+      "exp": 49,
+      "eggCycles": 10
     },
     {
-      "id": "176",
+      "id": 176,
       "name": "Togetic",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Fairy",
         "Flying"
       ],
-      "attack": "105",
+      "attack": 105,
       "levelType": "fast",
-      "exp": "142",
-      "eggCycles": "10"
+      "exp": 142,
+      "eggCycles": 10
     },
     {
-      "id": "177",
+      "id": 177,
       "name": "Natu",
-      "catchRate": "190",
+      "catchRate": 190,
       "evolution": "Xatu",
-      "evoLevel": "25",
+      "evoLevel": 25,
       "type": [
         "Psychic",
         "Flying"
       ],
-      "attack": "50",
+      "attack": 50,
       "levelType": "mediumfast",
-      "exp": "64",
-      "eggCycles": "20"
+      "exp": 64,
+      "eggCycles": 20
     },
     {
-      "id": "178",
+      "id": 178,
       "name": "Xatu",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Psychic",
         "Flying"
       ],
-      "attack": "75",
+      "attack": 75,
       "levelType": "mediumfast",
-      "exp": "165",
-      "eggCycles": "20"
+      "exp": 165,
+      "eggCycles": 20
     },
     {
-      "id": "179",
+      "id": 179,
       "name": "Mareep",
-      "catchRate": "235",
+      "catchRate": 235,
       "evolution": "Flaaffy",
-      "evoLevel": "15",
+      "evoLevel": 15,
       "type": [
         "Electric"
       ],
-      "attack": "45",
+      "attack": 45,
       "levelType": "mediumslow",
-      "exp": "56",
-      "eggCycles": "20"
+      "exp": 56,
+      "eggCycles": 20
     },
     {
-      "id": "180",
+      "id": 180,
       "name": "Flaaffy",
-      "catchRate": "120",
+      "catchRate": 120,
       "evolution": "Ampharos",
-      "evoLevel": "30",
+      "evoLevel": 30,
       "type": [
         "Electric"
       ],
-      "attack": "60",
+      "attack": 60,
       "levelType": "mediumslow",
-      "exp": "128",
-      "eggCycles": "20"
+      "exp": 128,
+      "eggCycles": 20
     },
     {
-      "id": "181",
+      "id": 181,
       "name": "Ampharos",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Electric"
       ],
-      "attack": "110",
+      "attack": 110,
       "levelType": "mediumslow",
-      "exp": "230",
-      "eggCycles": "20"
+      "exp": 230,
+      "eggCycles": 20
     },
     {
-      "id": "182",
+      "id": 182,
       "name": "Bellossom",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Grass"
       ],
-      "attack": "100",
+      "attack": 100,
       "levelType": "mediumslow",
-      "exp": "221",
-      "eggCycles": "20"
+      "exp": 221,
+      "eggCycles": 20
     },
     {
-      "id": "183",
+      "id": 183,
       "name": "Marill",
-      "catchRate": "190",
+      "catchRate": 190,
       "evolution": "Azumarill",
-      "evoLevel": "18",
+      "evoLevel": 18,
       "type": [
         "Water",
         "Fairy"
       ],
-      "attack": "50",
+      "attack": 50,
       "levelType": "fast",
-      "exp": "88",
-      "eggCycles": "10"
+      "exp": 88,
+      "eggCycles": 10
     },
     {
-      "id": "184",
+      "id": 184,
       "name": "Azumarill",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Water",
         "Fairy"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "fast",
-      "exp": "189",
-      "eggCycles": "10"
+      "exp": 189,
+      "eggCycles": 10
     },
     {
-      "id": "185",
+      "id": 185,
       "name": "Sudowoodo",
-      "catchRate": "65",
+      "catchRate": 65,
       "type": [
         "Rock"
       ],
-      "attack": "100",
+      "attack": 100,
       "levelType": "mediumfast",
-      "exp": "144",
-      "eggCycles": "20"
+      "exp": 144,
+      "eggCycles": 20
     },
     {
-      "id": "186",
+      "id": 186,
       "name": "Politoed",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Water"
       ],
-      "attack": "100",
+      "attack": 100,
       "levelType": "mediumslow",
-      "exp": "225",
-      "eggCycles": "20"
+      "exp": 225,
+      "eggCycles": 20
     },
     {
-      "id": "187",
+      "id": 187,
       "name": "Hoppip",
-      "catchRate": "255",
+      "catchRate": 255,
       "evolution": "Skiploom",
-      "evoLevel": "18",
+      "evoLevel": 18,
       "type": [
         "Grass",
         "Flying"
       ],
-      "attack": "55",
+      "attack": 55,
       "levelType": "mediumslow",
-      "exp": "50",
-      "eggCycles": "20"
+      "exp": 50,
+      "eggCycles": 20
     },
     {
-      "id": "188",
+      "id": 188,
       "name": "Skiploom",
-      "catchRate": "120",
+      "catchRate": 120,
       "evolution": "Jumpluff",
-      "evoLevel": "27",
+      "evoLevel": 27,
       "type": [
         "Grass",
         "Flying"
       ],
-      "attack": "65",
+      "attack": 65,
       "levelType": "mediumslow",
-      "exp": "119",
-      "eggCycles": "20"
+      "exp": 119,
+      "eggCycles": 20
     },
     {
-      "id": "189",
+      "id": 189,
       "name": "Jumpluff",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Grass",
         "Flying"
       ],
-      "attack": "95",
+      "attack": 95,
       "levelType": "mediumslow",
-      "exp": "207",
-      "eggCycles": "20"
+      "exp": 207,
+      "eggCycles": 20
     },
     {
-      "id": "190",
+      "id": 190,
       "name": "Aipom",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Normal"
       ],
-      "attack": "70",
+      "attack": 70,
       "levelType": "fast",
-      "exp": "72",
-      "eggCycles": "20"
+      "exp": 72,
+      "eggCycles": 20
     },
     {
-      "id": "191",
+      "id": 191,
       "name": "Sunkern",
-      "catchRate": "235",
+      "catchRate": 235,
       "evolution": "Sunflora",
       "evoLevel": "",
       "type": [
         "Grass"
       ],
-      "attack": "30",
+      "attack": 30,
       "levelType": "mediumslow",
-      "exp": "36",
-      "eggCycles": "20"
+      "exp": 36,
+      "eggCycles": 20
     },
     {
-      "id": "192",
+      "id": 192,
       "name": "Sunflora",
-      "catchRate": "120",
+      "catchRate": 120,
       "type": [
         "Grass"
       ],
-      "attack": "85",
+      "attack": 85,
       "levelType": "mediumslow",
-      "exp": "149",
-      "eggCycles": "20"
+      "exp": 149,
+      "eggCycles": 20
     },
     {
-      "id": "193",
+      "id": 193,
       "name": "Yanma",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Bug",
         "Flying"
       ],
-      "attack": "65",
+      "attack": 65,
       "levelType": "mediumfast",
-      "exp": "78",
-      "eggCycles": "20"
+      "exp": 78,
+      "eggCycles": 20
     },
     {
-      "id": "194",
+      "id": 194,
       "name": "Wooper",
-      "catchRate": "255",
+      "catchRate": 255,
       "evolution": "Quagsire",
-      "evoLevel": "20",
+      "evoLevel": 20,
       "type": [
         "Water",
         "Ground"
       ],
-      "attack": "45",
+      "attack": 45,
       "levelType": "mediumfast",
-      "exp": "42",
-      "eggCycles": "20"
+      "exp": 42,
+      "eggCycles": 20
     },
     {
-      "id": "195",
+      "id": 195,
       "name": "Quagsire",
-      "catchRate": "90",
+      "catchRate": 90,
       "type": [
         "Water",
         "Ground"
       ],
-      "attack": "85",
+      "attack": 85,
       "levelType": "mediumfast",
-      "exp": "151",
-      "eggCycles": "20"
+      "exp": 151,
+      "eggCycles": 20
     },
     {
-      "id": "196",
+      "id": 196,
       "name": "Espeon",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Psychic"
       ],
-      "attack": "95",
+      "attack": 95,
       "levelType": "mediumfast",
-      "exp": "184",
-      "eggCycles": "35"
+      "exp": 184,
+      "eggCycles": 35
     },
     {
-      "id": "197",
+      "id": 197,
       "name": "Umbreon",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Dark"
       ],
-      "attack": "130",
+      "attack": 130,
       "levelType": "mediumfast",
-      "exp": "184",
-      "eggCycles": "35"
+      "exp": 184,
+      "eggCycles": 35
     },
     {
-      "id": "198",
+      "id": 198,
       "name": "Murkrow",
-      "catchRate": "30",
+      "catchRate": 30,
       "type": [
         "Dark",
         "Flying"
       ],
-      "attack": "85",
+      "attack": 85,
       "levelType": "mediumslow",
-      "exp": "81",
-      "eggCycles": "20"
+      "exp": 81,
+      "eggCycles": 20
     },
     {
-      "id": "199",
+      "id": 199,
       "name": "Slowking",
-      "catchRate": "70",
+      "catchRate": 70,
       "type": [
         "Water",
         "Psychic"
       ],
-      "attack": "110",
+      "attack": 110,
       "levelType": "mediumfast",
-      "exp": "172",
-      "eggCycles": "20"
+      "exp": 172,
+      "eggCycles": 20
     },
     {
-      "id": "200",
+      "id": 200,
       "name": "Misdreavus",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Ghost"
       ],
-      "attack": "85",
+      "attack": 85,
       "levelType": "fast",
-      "exp": "87",
-      "eggCycles": "25"
+      "exp": 87,
+      "eggCycles": 25
     },
     {
-      "id": "201",
+      "id": 201,
       "name": "Unown",
-      "catchRate": "225",
+      "catchRate": 225,
       "type": [
         "Psychic"
       ],
-      "attack": "72",
+      "attack": 72,
       "levelType": "mediumfast",
-      "exp": "118",
-      "eggCycles": "40"
+      "exp": 118,
+      "eggCycles": 40
     },
     {
-      "id": "202",
+      "id": 202,
       "name": "Wobbuffet",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Psychic"
       ],
-      "attack": "58",
+      "attack": 58,
       "levelType": "mediumfast",
-      "exp": "142",
-      "eggCycles": "20"
+      "exp": 142,
+      "eggCycles": 20
     },
     {
-      "id": "203",
+      "id": 203,
       "name": "Girafarig",
-      "catchRate": "60",
+      "catchRate": 60,
       "type": [
         "Normal",
         "Psychic"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "mediumfast",
-      "exp": "159",
-      "eggCycles": "20"
+      "exp": 159,
+      "eggCycles": 20
     },
     {
-      "id": "204",
+      "id": 204,
       "name": "Pineco",
-      "catchRate": "190",
+      "catchRate": 190,
       "evolution": "Forretress",
-      "evoLevel": "31",
+      "evoLevel": 31,
       "type": [
         "Bug"
       ],
-      "attack": "65",
+      "attack": 65,
       "levelType": "mediumfast",
-      "exp": "58",
-      "eggCycles": "20"
+      "exp": 58,
+      "eggCycles": 20
     },
     {
-      "id": "205",
+      "id": 205,
       "name": "Forretress",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Bug",
         "Steel"
       ],
-      "attack": "90",
+      "attack": 90,
       "levelType": "mediumfast",
-      "exp": "163",
-      "eggCycles": "20"
+      "exp": 163,
+      "eggCycles": 20
     },
     {
-      "id": "206",
+      "id": 206,
       "name": "Dunsparce",
-      "catchRate": "190",
+      "catchRate": 190,
       "type": [
         "Normal"
       ],
-      "attack": "70",
+      "attack": 70,
       "levelType": "mediumfast",
-      "exp": "145",
-      "eggCycles": "20"
+      "exp": 145,
+      "eggCycles": 20
     },
     {
-      "id": "207",
+      "id": 207,
       "name": "Gligar",
-      "catchRate": "60",
+      "catchRate": 60,
       "type": [
         "Ground",
         "Flying"
       ],
-      "attack": "75",
+      "attack": 75,
       "levelType": "mediumslow",
-      "exp": "86",
-      "eggCycles": "20"
+      "exp": 86,
+      "eggCycles": 20
     },
     {
-      "id": "208",
+      "id": 208,
       "name": "Steelix",
-      "catchRate": "25",
+      "catchRate": 25,
       "type": [
         "Steel",
         "Ground"
       ],
-      "attack": "125",
+      "attack": 125,
       "levelType": "mediumfast",
-      "exp": "179",
-      "eggCycles": "25"
+      "exp": 179,
+      "eggCycles": 25
     },
     {
-      "id": "209",
+      "id": 209,
       "name": "Snubbull",
-      "catchRate": "190",
+      "catchRate": 190,
       "evolution": "Granbull",
-      "evoLevel": "23",
+      "evoLevel": 23,
       "type": [
         "Fairy"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "fast",
-      "exp": "60",
-      "eggCycles": "20"
+      "exp": 60,
+      "eggCycles": 20
     },
     {
-      "id": "210",
+      "id": 210,
       "name": "Granbull",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Fairy"
       ],
-      "attack": "120",
+      "attack": 120,
       "levelType": "fast",
-      "exp": "158",
-      "eggCycles": "20"
+      "exp": 158,
+      "eggCycles": 20
     },
     {
-      "id": "211",
+      "id": 211,
       "name": "Qwilfish",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Water",
         "Poison"
       ],
-      "attack": "95",
+      "attack": 95,
       "levelType": "mediumfast",
-      "exp": "88",
-      "eggCycles": "20"
+      "exp": 88,
+      "eggCycles": 20
     },
     {
-      "id": "212",
+      "id": 212,
       "name": "Scizor",
-      "catchRate": "25",
+      "catchRate": 25,
       "type": [
         "Bug",
         "Steel"
       ],
-      "attack": "150",
+      "attack": 150,
       "levelType": "mediumfast",
-      "exp": "175",
-      "eggCycles": "25"
+      "exp": 175,
+      "eggCycles": 25
     },
     {
-      "id": "213",
+      "id": 213,
       "name": "Shuckle",
-      "catchRate": "190",
+      "catchRate": 190,
       "type": [
         "Bug",
         "Rock"
       ],
-      "attack": "230",
+      "attack": 230,
       "levelType": "mediumslow",
-      "exp": "177",
-      "eggCycles": "20"
+      "exp": 177,
+      "eggCycles": 20
     },
     {
-      "id": "214",
+      "id": 214,
       "name": "Heracross",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Bug",
         "Fighting"
       ],
-      "attack": "185",
+      "attack": 185,
       "levelType": "slow",
-      "exp": "175",
-      "eggCycles": "25"
+      "exp": 175,
+      "eggCycles": 25
     },
     {
-      "id": "215",
+      "id": 215,
       "name": "Sneasel",
-      "catchRate": "60",
+      "catchRate": 60,
       "type": [
         "Dark",
         "Ice"
       ],
-      "attack": "95",
+      "attack": 95,
       "levelType": "mediumslow",
-      "exp": "86",
-      "eggCycles": "20"
+      "exp": 86,
+      "eggCycles": 20
     },
     {
-      "id": "216",
+      "id": 216,
       "name": "Teddiursa",
-      "catchRate": "120",
+      "catchRate": 120,
       "evolution": "Ursaring",
-      "evoLevel": "30",
+      "evoLevel": 30,
       "type": [
         "Normal"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "mediumfast",
-      "exp": "66",
-      "eggCycles": "20"
+      "exp": 66,
+      "eggCycles": 20
     },
     {
-      "id": "217",
+      "id": 217,
       "name": "Ursaring",
-      "catchRate": "60",
+      "catchRate": 60,
       "type": [
         "Normal"
       ],
-      "attack": "130",
+      "attack": 130,
       "levelType": "mediumfast",
-      "exp": "175",
-      "eggCycles": "20"
+      "exp": 175,
+      "eggCycles": 20
     },
     {
-      "id": "218",
+      "id": 218,
       "name": "Slugma",
-      "catchRate": "190",
+      "catchRate": 190,
       "evolution": "Magcargo",
-      "evoLevel": "38",
+      "evoLevel": 38,
       "type": [
         "Fire"
       ],
-      "attack": "40",
+      "attack": 40,
       "levelType": "mediumfast",
-      "exp": "50",
-      "eggCycles": "20"
+      "exp": 50,
+      "eggCycles": 20
     },
     {
-      "id": "219",
+      "id": 219,
       "name": "Magcargo",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Fire",
         "Rock"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "mediumfast",
-      "exp": "151",
-      "eggCycles": "20"
+      "exp": 151,
+      "eggCycles": 20
     },
     {
-      "id": "220",
+      "id": 220,
       "name": "Swinub",
-      "catchRate": "225",
+      "catchRate": 225,
       "evolution": "Piloswine",
-      "evoLevel": "33",
+      "evoLevel": 33,
       "type": [
         "Ice",
         "Ground"
       ],
-      "attack": "50",
+      "attack": 50,
       "levelType": "slow",
-      "exp": "50",
-      "eggCycles": "20"
+      "exp": 50,
+      "eggCycles": 20
     },
     {
-      "id": "221",
+      "id": 221,
       "name": "Piloswine",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Ice",
         "Ground"
       ],
-      "attack": "100",
+      "attack": 100,
       "levelType": "slow",
-      "exp": "158",
-      "eggCycles": "20"
+      "exp": 158,
+      "eggCycles": 20
     },
     {
-      "id": "222",
+      "id": 222,
       "name": "Corsola",
-      "catchRate": "60",
+      "catchRate": 60,
       "type": [
         "Water",
         "Rock"
       ],
-      "attack": "95",
+      "attack": 95,
       "levelType": "fast",
-      "exp": "144",
-      "eggCycles": "20"
+      "exp": 144,
+      "eggCycles": 20
     },
     {
-      "id": "223",
+      "id": 223,
       "name": "Remoraid",
-      "catchRate": "190",
+      "catchRate": 190,
       "evolution": "Octillery",
-      "evoLevel": "25",
+      "evoLevel": 25,
       "type": [
         "Water"
       ],
-      "attack": "65",
+      "attack": 65,
       "levelType": "mediumfast",
-      "exp": "60",
-      "eggCycles": "20"
+      "exp": 60,
+      "eggCycles": 20
     },
     {
-      "id": "224",
+      "id": 224,
       "name": "Octillery",
-      "catchRate": "75",
+      "catchRate": 75,
       "type": [
         "Water"
       ],
-      "attack": "105",
+      "attack": 105,
       "levelType": "mediumfast",
-      "exp": "168",
-      "eggCycles": "20"
+      "exp": 168,
+      "eggCycles": 20
     },
     {
-      "id": "225",
+      "id": 225,
       "name": "Delibird",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Ice",
         "Flying"
       ],
-      "attack": "55",
+      "attack": 55,
       "levelType": "fast",
-      "exp": "116",
-      "eggCycles": "20"
+      "exp": 116,
+      "eggCycles": 20
     },
     {
-      "id": "226",
+      "id": 226,
       "name": "Mantine",
-      "catchRate": "25",
+      "catchRate": 25,
       "type": [
         "Water",
         "Flying"
       ],
-      "attack": "140",
+      "attack": 140,
       "levelType": "slow",
-      "exp": "170",
-      "eggCycles": "25"
+      "exp": 170,
+      "eggCycles": 25
     },
     {
-      "id": "227",
+      "id": 227,
       "name": "Skarmory",
-      "catchRate": "25",
+      "catchRate": 25,
       "type": [
         "Steel",
         "Flying"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "slow",
-      "exp": "163",
-      "eggCycles": "25"
+      "exp": 163,
+      "eggCycles": 25
     },
     {
-      "id": "228",
+      "id": 228,
       "name": "Houndour",
-      "catchRate": "120",
+      "catchRate": 120,
       "evolution": "Houndoom",
-      "evoLevel": "24",
+      "evoLevel": 24,
       "type": [
         "Dark",
         "Fire"
       ],
-      "attack": "60",
+      "attack": 60,
       "levelType": "slow",
-      "exp": "66",
-      "eggCycles": "20"
+      "exp": 66,
+      "eggCycles": 20
     },
     {
-      "id": "229",
+      "id": 229,
       "name": "Houndoom",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Dark",
         "Fire"
       ],
-      "attack": "90",
+      "attack": 90,
       "levelType": "slow",
-      "exp": "175",
-      "eggCycles": "20"
+      "exp": 175,
+      "eggCycles": 20
     },
     {
-      "id": "230",
+      "id": 230,
       "name": "Kingdra",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Water",
         "Dragon"
       ],
-      "attack": "95",
+      "attack": 95,
       "levelType": "mediumfast",
-      "exp": "243",
-      "eggCycles": "20"
+      "exp": 243,
+      "eggCycles": 20
     },
     {
-      "id": "231",
+      "id": 231,
       "name": "Phanpy",
-      "catchRate": "120",
+      "catchRate": 120,
       "evolution": "Donphan",
-      "evoLevel": "25",
+      "evoLevel": 25,
       "type": [
         "Ground"
       ],
-      "attack": "60",
+      "attack": 60,
       "levelType": "mediumfast",
-      "exp": "66",
-      "eggCycles": "20"
+      "exp": 66,
+      "eggCycles": 20
     },
     {
-      "id": "232",
+      "id": 232,
       "name": "Donphan",
-      "catchRate": "60",
+      "catchRate": 60,
       "type": [
         "Ground"
       ],
-      "attack": "120",
+      "attack": 120,
       "levelType": "mediumfast",
-      "exp": "175",
-      "eggCycles": "20"
+      "exp": 175,
+      "eggCycles": 20
     },
     {
-      "id": "233",
+      "id": 233,
       "name": "Porygon2",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Normal"
       ],
-      "attack": "95",
+      "attack": 95,
       "levelType": "mediumfast",
-      "exp": "180",
-      "eggCycles": "20"
+      "exp": 180,
+      "eggCycles": 20
     },
     {
-      "id": "234",
+      "id": 234,
       "name": "Stantler",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Normal"
       ],
-      "attack": "95",
+      "attack": 95,
       "levelType": "slow",
-      "exp": "163",
-      "eggCycles": "20"
+      "exp": 163,
+      "eggCycles": 20
     },
     {
-      "id": "235",
+      "id": 235,
       "name": "Smeargle",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Normal"
       ],
-      "attack": "45",
+      "attack": 45,
       "levelType": "fast",
-      "exp": "88",
-      "eggCycles": "20"
+      "exp": 88,
+      "eggCycles": 20
     },
     {
-      "id": "236",
+      "id": 236,
       "name": "Tyrogue",
-      "catchRate": "75",
+      "catchRate": 75,
       "evolution": "Hitmonlee, Hitmonchan, Hitmontop",
       "evoLevel": "20, 20, 20",
       "type": [
         "Fighting"
       ],
-      "attack": "35",
+      "attack": 35,
       "levelType": "mediumfast",
-      "exp": "42",
-      "eggCycles": "25"
+      "exp": 42,
+      "eggCycles": 25
     },
     {
-      "id": "237",
+      "id": 237,
       "name": "Hitmontop",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Fighting"
       ],
-      "attack": "110",
+      "attack": 110,
       "levelType": "mediumfast",
-      "exp": "159",
-      "eggCycles": "25"
+      "exp": 159,
+      "eggCycles": 25
     },
     {
-      "id": "238",
+      "id": 238,
       "name": "Smoochum",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Jynx",
-      "evoLevel": "30",
+      "evoLevel": 30,
       "type": [
         "Ice",
         "Psychic"
       ],
-      "attack": "65",
+      "attack": 65,
       "levelType": "mediumfast",
-      "exp": "61",
-      "eggCycles": "25"
+      "exp": 61,
+      "eggCycles": 25
     },
     {
-      "id": "239",
+      "id": 239,
       "name": "Elekid",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Electabuzz",
-      "evoLevel": "30",
+      "evoLevel": 30,
       "type": [
         "Electric"
       ],
-      "attack": "63",
+      "attack": 63,
       "levelType": "mediumfast",
-      "exp": "72",
-      "eggCycles": "25"
+      "exp": 72,
+      "eggCycles": 25
     },
     {
-      "id": "240",
+      "id": 240,
       "name": "Magby",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Magmar",
-      "evoLevel": "30",
+      "evoLevel": 30,
       "type": [
         "Fire"
       ],
-      "attack": "75",
+      "attack": 75,
       "levelType": "mediumfast",
-      "exp": "73",
-      "eggCycles": "25"
+      "exp": 73,
+      "eggCycles": 25
     },
     {
-      "id": "241",
+      "id": 241,
       "name": "Miltank",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Normal"
       ],
-      "attack": "80",
+      "attack": 80,
       "levelType": "slow",
-      "exp": "172",
-      "eggCycles": "20"
+      "exp": 172,
+      "eggCycles": 20
     },
     {
-      "id": "242",
+      "id": 242,
       "name": "Blissey",
-      "catchRate": "30",
+      "catchRate": 30,
       "type": [
         "Normal"
       ],
-      "attack": "135",
+      "attack": 135,
       "levelType": "fast",
-      "exp": "608",
-      "eggCycles": "40"
+      "exp": 608,
+      "eggCycles": 40
     },
     {
-      "id": "243",
+      "id": 243,
       "name": "Raikou",
-      "catchRate": "3",
+      "catchRate": 3,
       "type": [
         "Electric"
       ],
-      "attack": "100",
+      "attack": 100,
       "levelType": "slow",
-      "exp": "261",
-      "eggCycles": "80"
+      "exp": 261,
+      "eggCycles": 80
     },
     {
-      "id": "244",
+      "id": 244,
       "name": "Entei",
-      "catchRate": "3",
+      "catchRate": 3,
       "type": [
         "Fire"
       ],
-      "attack": "115",
+      "attack": 115,
       "levelType": "slow",
-      "exp": "261",
-      "eggCycles": "80"
+      "exp": 261,
+      "eggCycles": 80
     },
     {
-      "id": "245",
+      "id": 245,
       "name": "Suicune",
-      "catchRate": "3",
+      "catchRate": 3,
       "type": [
         "Water"
       ],
-      "attack": "115",
+      "attack": 115,
       "levelType": "slow",
-      "exp": "261",
-      "eggCycles": "80"
+      "exp": 261,
+      "eggCycles": 80
     },
     {
-      "id": "246",
+      "id": 246,
       "name": "Larvitar",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Pupitar",
-      "evoLevel": "30",
+      "evoLevel": 30,
       "type": [
         "Rock",
         "Ground"
       ],
-      "attack": "64",
+      "attack": 64,
       "levelType": "slow",
-      "exp": "60",
-      "eggCycles": "40"
+      "exp": 60,
+      "eggCycles": 40
     },
     {
-      "id": "247",
+      "id": 247,
       "name": "Pupitar",
-      "catchRate": "45",
+      "catchRate": 45,
       "evolution": "Tyranitar",
-      "evoLevel": "55",
+      "evoLevel": 55,
       "type": [
         "Rock",
         "Ground"
       ],
-      "attack": "84",
+      "attack": 84,
       "levelType": "slow",
-      "exp": "144",
-      "eggCycles": "40"
+      "exp": 144,
+      "eggCycles": 40
     },
     {
-      "id": "248",
+      "id": 248,
       "name": "Tyranitar",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Rock",
         "Dark"
       ],
-      "attack": "164",
+      "attack": 164,
       "levelType": "slow",
-      "exp": "270",
-      "eggCycles": "40"
+      "exp": 270,
+      "eggCycles": 40
     },
     {
-      "id": "249",
+      "id": 249,
       "name": "Lugia",
-      "catchRate": "3",
+      "catchRate": 3,
       "type": [
         "Psychic",
         "Flying"
       ],
-      "attack": "154",
+      "attack": 154,
       "levelType": "slow",
-      "exp": "306",
-      "eggCycles": "120"
+      "exp": 306,
+      "eggCycles": 120
     },
     {
-      "id": "250",
+      "id": 250,
       "name": "Ho-Oh",
-      "catchRate": "3",
+      "catchRate": 3,
       "type": [
         "Fire",
         "Flying"
       ],
-      "attack": "154",
+      "attack": 154,
       "levelType": "slow",
-      "exp": "306",
-      "eggCycles": "120"
+      "exp": 306,
+      "eggCycles": 120
     },
     {
-      "id": "251",
+      "id": 251,
       "name": "Celebi",
-      "catchRate": "45",
+      "catchRate": 45,
       "type": [
         "Psychic",
         "Grass"
       ],
-      "attack": "100",
+      "attack": 100,
       "levelType": "mediumslow",
-      "exp": "270",
-      "eggCycles": "120"
+      "exp": 270,
+      "eggCycles": 120
     }
 ];
 


### PR DESCRIPTION
All Johto and Hoenn Pokemon can now evolve.
They couldn't evolve due to their `evoLevel` being a string instead if a number