### PR TITLE
Refactor OakItem references to use GameConstants enum

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -534,15 +534,15 @@
                     <div>
                         <div>
                             <img class="clickable" src=""
-                                 data-bind="attr:{ src: '/assets/images/oakitems/' + $data.name() + '.png'},
-                                  css: {'oak-item-small-selected': OakItemRunner.isActive($data.name()),
-                                        'oak-item-small': !OakItemRunner.isActive($data.name()),
-                                        'oak-item-locked': !OakItemRunner.isUnlocked($data.name())
+                                 data-bind="attr:{ src: '/assets/images/oakitems/' + $data.displayName() + '.png'},
+                                  css: {'oak-item-small-selected': OakItemRunner.isActive($data.id),
+                                        'oak-item-small': !OakItemRunner.isActive($data.id),
+                                        'oak-item-locked': !OakItemRunner.isUnlocked($data.id)
 
                                         },
                                  event: {
-                                    mouseover: function(){OakItemRunner.hover($data.name())},
-                                    click: function(){OakItemRunner.click($data.name())},
+                                    mouseover: function(){OakItemRunner.hover($data.id)},
+                                    click: function(){OakItemRunner.click($data.id)},
                                     mouseout : function(){OakItemRunner.hoverRelease()}
                                     }">
                         </div>
@@ -556,7 +556,7 @@
                         <div class="row justify-content-sm-center">
                             <div style="height:20px;" class="col">
                                 <b>
-                                    <span data-bind="text: OakItemRunner.inspectedItem().name()"></span>
+                                    <span data-bind="text: OakItemRunner.inspectedItem().displayName()"></span>
                                 </b>
                             </div>
                         </div>

--- a/src/scripts/Battle.ts
+++ b/src/scripts/Battle.ts
@@ -39,7 +39,7 @@ class Battle {
         if (!this.enemyPokemon().isAlive()) {
             return;
         }
-        OakItemRunner.use("Poison Barb");
+        OakItemRunner.use(GameConstants.OakItem.PoisonBarb);
         GameHelper.incrementObservable(player.statistics.clicks)
         this.enemyPokemon().damage(player.calculateClickAttack());
         if (!this.enemyPokemon().isAlive()) {
@@ -90,8 +90,8 @@ class Battle {
 
     protected static calculateActualCatchRate(pokeBall: GameConstants.Pokeball) {
         let pokeballBonus = GameConstants.getCatchBonus(pokeBall);
-        let oakBonus = OakItemRunner.isActive("Magic Ball") ? 
-            OakItemRunner.calculateBonus("Magic Ball") : 0;
+        let oakBonus = OakItemRunner.isActive(GameConstants.OakItem.MagicBall) ? 
+            OakItemRunner.calculateBonus(GameConstants.OakItem.MagicBall) : 0;
         let totalChance = this.enemyPokemon().catchRate + pokeballBonus + oakBonus;
         return totalChance;
     }

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -110,14 +110,14 @@ namespace GameConstants {
     }
 
     export enum OakItem {
-        "Magic Ball" = 0,
-        "Amulet Coin",
-        "Poison Barb",
-        "Exp Share",
-        "Sprayduck",
-        "Shiny Charm",
-        "Blaze Cassette",
-        "Cell Battery",
+        MagicBall = 0,
+        AmuletCoin,
+        PoisonBarb,
+        ExpShare,
+        Sprayduck,
+        ShinyCharm,
+        BlazeCassette,
+        CellBattery,
     }
 
     // Dungeons

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -318,7 +318,7 @@ class Player {
     private _caughtAmount: Array<KnockoutObservable<number>>;
 
     public calculateClickAttack(): number {
-        let oakItemBonus = OakItemRunner.isActive("Poison Barb") ? (1 + OakItemRunner.calculateBonus("Poison Barb") / 100) : 1;
+        let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.PoisonBarb) ? (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.PoisonBarb) / 100) : 1;
         return Math.floor(Math.pow(this.caughtPokemonList.length + 1, 1.4) * oakItemBonus);
     }
 
@@ -403,7 +403,7 @@ class Player {
     }
 
     public capturePokemon(pokemonName: string, shiny: boolean = false, supressNotification = false) {
-        OakItemRunner.use("Magic Ball");
+        OakItemRunner.use(GameConstants.OakItem.MagicBall);
         let pokemonData = PokemonHelper.getPokemonByName(pokemonName);
         if (!this.alreadyCaughtPokemon(pokemonName)) {
             let caughtPokemon: CaughtPokemon = new CaughtPokemon(pokemonData, false, 0, 0);
@@ -436,9 +436,9 @@ class Player {
     }
 
     public gainMoney(money: number) {
-        OakItemRunner.use("Amulet Coin");
+        OakItemRunner.use(GameConstants.OakItem.AmuletCoin);
         // TODO add money multipliers
-        let oakItemBonus = OakItemRunner.isActive("Amulet Coin") ? (1 + OakItemRunner.calculateBonus("Amulet Coin") / 100) : 1;
+        let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.AmuletCoin) ? (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.AmuletCoin) / 100) : 1;
         let moneytogain = Math.floor(money * oakItemBonus * (1 + AchievementHandler.achievementBonus()))
         this._money(this._money() + moneytogain);
         GameHelper.incrementObservable(this.statistics.totalMoney, moneytogain);
@@ -521,10 +521,10 @@ class Player {
     }
 
     public gainExp(exp: number, level: number, trainer: boolean) {
-        OakItemRunner.use("Exp Share");
+        OakItemRunner.use(GameConstants.OakItem.ExpShare);
         // TODO add exp multipliers
         let trainerBonus = trainer ? 1.5 : 1;
-        let oakItemBonus = OakItemRunner.isActive("Exp Share") ? 1 + (OakItemRunner.calculateBonus("Exp Share") / 100) : 1;
+        let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.ExpShare) ? 1 + (OakItemRunner.calculateBonus(GameConstants.OakItem.ExpShare) / 100) : 1;
         let expTotal = Math.floor(exp * level * trainerBonus * oakItemBonus * (1 + AchievementHandler.achievementBonus()) / 9);
 
         for (let pokemon of this._caughtPokemonList()) {

--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -13,8 +13,8 @@ class BreedingHelper {
     }
 
     public static progressEggs(amount: number) {
-        if (OakItemRunner.isActive("Blaze Cassette")) {
-            amount *= (1 + OakItemRunner.calculateBonus("Blaze Cassette") / 100)
+        if (OakItemRunner.isActive(GameConstants.OakItem.BlazeCassette)) {
+            amount *= (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.BlazeCassette) / 100)
         }
         amount = Math.round(amount);
         for (let obj of player.eggList) {
@@ -23,7 +23,7 @@ class BreedingHelper {
                 continue;
             }
             egg.steps(egg.steps() + amount);
-            if (OakItemRunner.isActive("Shiny Charm")) {
+            if (OakItemRunner.isActive(GameConstants.OakItem.ShinyCharm)) {
                 egg.shinySteps += amount;
             }
             if (egg.steps() >= egg.totalSteps) {
@@ -64,7 +64,7 @@ class BreedingHelper {
         player.capturePokemon(egg.pokemon, shiny);
         player._eggList[index](null);
         GameHelper.incrementObservable(player.statistics.hatchedEggs);
-        OakItemRunner.use("Blaze Cassette");
+        OakItemRunner.use(GameConstants.OakItem.BlazeCassette);
     }
 
     public static createEgg(pokemonName: string, type = GameConstants.EggType.Pokemon): Egg {

--- a/src/scripts/farm/FarmRunner.ts
+++ b/src/scripts/farm/FarmRunner.ts
@@ -115,7 +115,7 @@ class FarmRunner {
                 Notifier.notify(`You earned ${money} money from the harvest!`, GameConstants.NotificationOption.success)
             }
             plot.berry(null);
-            OakItemRunner.use("Sprayduck");
+            OakItemRunner.use(GameConstants.OakItem.Sprayduck);
             return money;
         }
         return 0;

--- a/src/scripts/oakitems/OakItem.ts
+++ b/src/scripts/oakitems/OakItem.ts
@@ -1,5 +1,6 @@
 class OakItem {
-    public name: KnockoutObservable<string>;
+    public id: GameConstants.OakItem;
+    public displayName: KnockoutObservable<string>;
     public unlockReq: number;
     public description: KnockoutObservable<string>;
     public baseBonus: number;
@@ -7,17 +8,16 @@ class OakItem {
     public expGain: number;
     public level: KnockoutObservable<number>;
     public isActive: KnockoutObservable<boolean>;
-    public id: GameConstants.OakItem;
 
-    constructor(name: string, unlockReq: number, description: string, baseBonus: number, stepBonus: number, expGain: number) {
-        this.name = ko.observable(name);
+    constructor(id: GameConstants.OakItem, displayName: string, unlockReq: number, description: string, baseBonus: number, stepBonus: number, expGain: number) {
+        this.id = id;
+        this.displayName = ko.observable(displayName);
         this.unlockReq = unlockReq;
         this.description = ko.observable(description);
         this.baseBonus = baseBonus;
         this.stepBonus = stepBonus;
         this.expGain = expGain;
         this.level = ko.observable(0);
-        this.id = GameConstants.OakItem[name];
         this.isActive = ko.observable(false);
     }
 

--- a/src/scripts/oakitems/OakItemRunner.ts
+++ b/src/scripts/oakitems/OakItemRunner.ts
@@ -8,6 +8,7 @@ class OakItemRunner {
     public static initialize() {
         OakItemRunner.oakItemList = [];
 
+        // OakItemRunner.oakItemList must preserve the ordering of items in GameConstants.OakItem enum
         OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 20, "Gives a bonus to your catchrate", 5, 1, 2)));
         OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.AmuletCoin, "Amulet Coin", 30, "Gain more coins from battling", 25, 5, 1)));
         OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.PoisonBarb, "Poison Barb", 40, "Clicks do more damage", 25, 5, 3)));
@@ -64,11 +65,6 @@ class OakItemRunner {
     }
 
     public static getOakItemObject(id: GameConstants.OakItem): OakItem {
-        // for (let i = 0; i < OakItemRunner.oakItemList.length; i++) {
-        //     if (OakItemRunner.oakItemList[i]().id == id) {
-        //         return OakItemRunner.oakItemList[i]();
-        //     }
-        // }
         return OakItemRunner.oakItemList[id]();
     }
 

--- a/src/scripts/oakitems/OakItemRunner.ts
+++ b/src/scripts/oakitems/OakItemRunner.ts
@@ -8,7 +8,6 @@ class OakItemRunner {
     public static initialize() {
         OakItemRunner.oakItemList = [];
 
-        // OakItemRunner.oakItemList must preserve the ordering of items in GameConstants.OakItem enum
         OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 20, "Gives a bonus to your catchrate", 5, 1, 2)));
         OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.AmuletCoin, "Amulet Coin", 30, "Gain more coins from battling", 25, 5, 1)));
         OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.PoisonBarb, "Poison Barb", 40, "Clicks do more damage", 25, 5, 3)));
@@ -25,6 +24,11 @@ class OakItemRunner {
         // TODO implement use!
         // TODO implement functionality
         OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.CellBattery, "Cell Battery", 90, "Regenerate more mining energy", 25, 5, 4)));
+
+        // OakItemRunner.oakItemList must preserve the ordering of items in GameConstants.OakItem enum
+        if (!OakItemRunner.oakItemList.every((f, i)=>f().id==i)) {
+            throw new Error("Oak items are out of order!")
+        }
 
         let item: OakItem = OakItemRunner.getOakItemObject(GameConstants.OakItem.MagicBall);
         OakItemRunner.selectedItem(item);

--- a/src/scripts/oakitems/OakItemRunner.ts
+++ b/src/scripts/oakitems/OakItemRunner.ts
@@ -1,97 +1,99 @@
 class OakItemRunner {
 
     public static oakItemList: KnockoutObservable<OakItem>[];
-    public static blankOakItem: OakItem = new OakItem(" ", Number.MAX_VALUE, "", 0, 0, 0);
-    public static inspectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem("Magic Ball", 30, "Gives a bonus to your catchrate", 5, 1, 2));
-    public static selectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem("Magic Ball", 30, "Gives a bonus to your catchrate", 5, 1, 2));
+    // public static blankOakItem: OakItem = new OakItem(" ", Number.MAX_VALUE, "", 0, 0, 0);
+    public static inspectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 30, "Gives a bonus to your catchrate", 5, 1, 2));
+    public static selectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 30, "Gives a bonus to your catchrate", 5, 1, 2));
 
     public static initialize() {
         OakItemRunner.oakItemList = [];
 
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem("Magic Ball", 20, "Gives a bonus to your catchrate", 5, 1, 2)));
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem("Amulet Coin", 30, "Gain more coins from battling", 25, 5, 1)));
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem("Poison Barb", 40, "Clicks do more damage", 25, 5, 3)));
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem("Exp Share", 50, "Gain more exp from battling", 15, 3, 1)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 20, "Gives a bonus to your catchrate", 5, 1, 2)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.AmuletCoin, "Amulet Coin", 30, "Gain more coins from battling", 25, 5, 1)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.PoisonBarb, "Poison Barb", 40, "Clicks do more damage", 25, 5, 3)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.ExpShare, "Exp Share", 50, "Gain more exp from battling", 15, 3, 1)));
 
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem("Sprayduck", 60, "Makes your berries grow faster", 25, 5, 3    )));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Sprayduck, "Sprayduck", 60, "Makes your berries grow faster", 25, 5, 3    )));
 
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem("Shiny Charm", 70, "Encounter more shinies", 50, 100, 150)));
-
-        // TODO implement use!
-        // TODO implement functionality
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem("Blaze Cassette", 80, "Hatch eggs faster", 50, 10, 10)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.ShinyCharm, "Shiny Charm", 70, "Encounter more shinies", 50, 100, 150)));
 
         // TODO implement use!
         // TODO implement functionality
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem("Cell Battery", 90, "Regenerate more mining energy", 25, 5, 4)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.BlazeCassette, "Blaze Cassette", 80, "Hatch eggs faster", 50, 10, 10)));
 
-        let item: OakItem = OakItemRunner.getOakItemByName("Magic Ball");
+        // TODO implement use!
+        // TODO implement functionality
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.CellBattery, "Cell Battery", 90, "Regenerate more mining energy", 25, 5, 4)));
+
+        let item: OakItem = OakItemRunner.getOakItemObject(GameConstants.OakItem.MagicBall);
         OakItemRunner.selectedItem(item);
     }
 
     public static loadOakItems() {
         let oakItems = JSON.parse(JSON.stringify(player._oakItemsEquipped))
         for (let i = 0; i < oakItems.length; i++) {
-            OakItemRunner.activateOakItem(OakItemRunner.getOakItemByName(oakItems[i]).id);
+            OakItemRunner.activateOakItem(OakItemRunner.getOakItemObject(oakItems[i]).id);
         }
         for(let i = 0; i<OakItemRunner.oakItemList.length; i++){
             OakItemRunner.oakItemList[i]().calculateLevel();
         }
     }
 
-    public static hover(name: string) {
-        OakItemRunner.inspectedItem(OakItemRunner.getOakItemByName(name));
+    public static hover(id: GameConstants.OakItem) {
+        OakItemRunner.inspectedItem(OakItemRunner.getOakItemObject(id));
     }
 
     public static hoverRelease() {
         OakItemRunner.inspectedItem(OakItemRunner.selectedItem());
     }
 
-    public static click(name: string) {
-        let item: OakItem = OakItemRunner.getOakItemByName(name);
+    public static click(id: GameConstants.OakItem) {
+        let item: OakItem = OakItemRunner.getOakItemObject(id);
         OakItemRunner.selectedItem(item);
         if(item.isUnlocked()) {
             OakItemRunner.activateOakItem(item.id);
         }
     }
 
-    public static use(name: string) {
-        OakItemRunner.getOakItemByName(name).use();
+    public static use(id: GameConstants.OakItem) {
+        OakItemRunner.getOakItemObject(id).use();
     }
 
-    public static calculateBonus(name: string): number {
-        return OakItemRunner.getOakItemByName(name).calculateBonus()();
+    public static calculateBonus(id: GameConstants.OakItem): number {
+        return OakItemRunner.getOakItemObject(id).calculateBonus()();
     }
 
-    public static getOakItemByName(name: string): OakItem {
-        for (let i = 0; i < OakItemRunner.oakItemList.length; i++) {
-            if (OakItemRunner.oakItemList[i]().name() == name) {
-                return OakItemRunner.oakItemList[i]();
-            }
-        }
+    public static getOakItemObject(id: GameConstants.OakItem): OakItem {
+        // for (let i = 0; i < OakItemRunner.oakItemList.length; i++) {
+        //     if (OakItemRunner.oakItemList[i]().id == id) {
+        //         return OakItemRunner.oakItemList[i]();
+        //     }
+        // }
+        return OakItemRunner.oakItemList[id]();
     }
 
     public static setOakItemsEquipped() {
         player._oakItemsEquipped = [];
         for (let i = 0; i < OakItemRunner.oakItemList.length; i++) {
-            if (OakItemRunner.oakItemList[i]().isActive()) {
-                player._oakItemsEquipped.push(OakItemRunner.oakItemList[i]().name());
+            let oakObj = OakItemRunner.oakItemList[i]();
+            if (oakObj.isActive()) {
+                player._oakItemsEquipped.push(oakObj.id);
             }
         }
     }
 
-    public static activateOakItem(id) {
+    public static activateOakItem(id: GameConstants.OakItem) {
         if (player.calculateOakItemSlots()() == 1) {
             OakItemRunner.deactivateAllOakItems();
-            OakItemRunner.oakItemList[id]().isActive(true);
+            OakItemRunner.getOakItemObject(id).isActive(true);
         }
         else {
-            if (OakItemRunner.oakItemList[id]().isActive()) {
-                OakItemRunner.oakItemList[id]().isActive(false);
+            if (OakItemRunner.getOakItemObject(id).isActive()) {
+                OakItemRunner.getOakItemObject(id).isActive(false);
 
             } else {
                 if (OakItemRunner.getTotalActiveOakItems() < player.calculateOakItemSlots()()) {
-                    OakItemRunner.oakItemList[id]().isActive(true);
+                    OakItemRunner.getOakItemObject(id).isActive(true);
                 } else {
                     Notifier.notify("You can only have " + player.calculateOakItemSlots()() + " Oak items active at the same time", GameConstants.NotificationOption.warning);
                 }
@@ -117,17 +119,17 @@ class OakItemRunner {
         player.oakItemsEquipped = [];
     }
 
-    public static isActive(oakItemName): boolean {
+    public static isActive(id: GameConstants.OakItem): boolean {
         for (let i = 0; i < OakItemRunner.oakItemList.length; i++) {
-            if (OakItemRunner.oakItemList[i]().name() == oakItemName) {
+            if (OakItemRunner.oakItemList[i]().id == id) {
                 return OakItemRunner.oakItemList[i]().isActive();
             }
         }
     }
 
-    public static isUnlocked(oakItemName): boolean {
+    public static isUnlocked(id: GameConstants.OakItem): boolean {
         for (let i = 0; i < OakItemRunner.oakItemList.length; i++) {
-            if (OakItemRunner.oakItemList[i]().name() == oakItemName) {
+            if (OakItemRunner.oakItemList[i]().id == id) {
                 return OakItemRunner.oakItemList[i]().isUnlocked();
             }
         }

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -50,13 +50,13 @@ class PokemonFactory {
      * @returns {boolean}
      */
     public static generateShiny(chance: number): boolean {
-        chance = OakItemRunner.isActive("Shiny Charm") ? chance / (1 + OakItemRunner.calculateBonus("Shiny Charm") / 100) : chance;
+        chance = OakItemRunner.isActive(GameConstants.OakItem.ShinyCharm) ? chance / (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.ShinyCharm) / 100) : chance;
 
         let rand: number = Math.floor(Math.random() * chance) + 1;
 
         if (rand <= 1) {
             Notifier.notify("You encounter a shiny Pokémon...", GameConstants.NotificationOption.warning);
-            OakItemRunner.use("Shiny Charm");
+            OakItemRunner.use(GameConstants.OakItem.ShinyCharm);
             return true;
         }
         return false;

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -64,14 +64,14 @@ class QuestHelper{
                 return new UsePokeballQuest(pokeball, amount);
             case "UseOakItem":
                 let possibleItems = [
-                    GameConstants.OakItem["Magic Ball"],
-                    GameConstants.OakItem["Amulet Coin"],
-                    //GameConstants.OakItem["Poison Barb"],
-                    GameConstants.OakItem["Exp Share"],
-                    //GameConstants.OakItem["Sprayduck"],
-                    //GameConstants.OakItem["Shiny Charm"],
-                    //GameConstants.OakItem["Blaze Cassette"],
-                    //GameConstants.OakItem["Cell Battery"],
+                    GameConstants.OakItem.MagicBall,
+                    GameConstants.OakItem.AmuletCoin,
+                    //GameConstants.OakItem.PoisonBarb,
+                    GameConstants.OakItem.ExpShare,
+                    //GameConstants.OakItem.Sprayduck,
+                    //GameConstants.OakItem.ShinyCharm,
+                    //GameConstants.OakItem.BlazeCassette,
+                    //GameConstants.OakItem.CellBattery,
                 ]
                 let oakItem = SeededRand.fromArray(possibleItems);
                 amount = SeededRand.intBetween(100, 500);

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -99,8 +99,8 @@ class Underground {
     public static gainEnergy() {
         if (player._mineEnergy() < player._maxMineEnergy()) {
             let multiplier = 1;
-            if(OakItemRunner.isActive("Cell Battery")){
-                multiplier += (OakItemRunner.calculateBonus("Cell Battery") / 100);
+            if(OakItemRunner.isActive(GameConstants.OakItem.CellBattery)){
+                multiplier += (OakItemRunner.calculateBonus(GameConstants.OakItem.CellBattery) / 100);
             }
             player._mineEnergy( Math.min(player._maxMineEnergy(), player._mineEnergy() + (multiplier*player.mineEnergyGain)) );
             if(player._mineEnergy() === player._maxMineEnergy()){


### PR DESCRIPTION
Refactored all functions relating to Oak items to use `GameConstants.OakItem` enum

Before testing/updating your game for this change, be sure to deactivate all your Oak items. Otherwise, `OakItemRunner.loadOakItems` will fail. 

I tested all typical Oak item use cases, including activation/deactivation, application of effects, related quest progress, and saving/loading of player Oak item status.

Closes #297 