### PR TITLE
Refactor item price settings

### DIFF
--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -534,21 +534,40 @@ namespace GameConstants {
     }
 
     export const ItemPrice = {
+        // Money
         "Pokeball": 100,
         "Greatball": 500,
         "Ultraball": 2000,
         "Masterball": 10000,
+
         "xAttack": 600,
         "xClick": 400,
         "xExp": 800,
         "Token_collector": 1000,
         "Item_magnet": 1500,
         "Lucky_incense": 2000,
+
+        "SmallRestore": 100,
+        "MediumRestore": 100,
+        "LargeRestore": 100,
+
+        "PokeBlock": 0,
+
+        "Protein": 0,
+        "RareCandy": 0,
+
+        // Quest points
         "Eevee": 5000,
         "Porygon": 2000,
         "Jynx": 2500,
         "Mr_Mime": 1500,
         "Lickitung": 1000,
+
+        // TODO: Set prices for different kinds of eggs and stones
+        "Egg": 1000,
+        "EvolutionStone": 2500,
+
+        "Dungeon_ticket": 250,
     };
 
     export enum StoneType {

--- a/src/scripts/items/BattleItem.ts
+++ b/src/scripts/items/BattleItem.ts
@@ -4,29 +4,7 @@ class BattleItem extends Item {
     type: GameConstants.BattleItemType;
 
     constructor(type: GameConstants.BattleItemType) {
-        let basePrice = 1000;
-
-        switch (type) {
-            case GameConstants.BattleItemType.xAttack:
-                basePrice = GameConstants.ItemPrice.xAttack;
-                break;
-            case GameConstants.BattleItemType.xClick:
-                basePrice = GameConstants.ItemPrice.xClick;
-                break;
-            case GameConstants.BattleItemType.xExp:
-                basePrice = GameConstants.ItemPrice.xExp;
-                break;
-            case GameConstants.BattleItemType.Token_collector:
-                basePrice = GameConstants.ItemPrice.Token_collector;
-                break;
-            case GameConstants.BattleItemType.Item_magnet:
-                basePrice = GameConstants.ItemPrice.Item_magnet;
-                break;
-            case GameConstants.BattleItemType.Lucky_incense:
-                basePrice = GameConstants.ItemPrice.Lucky_incense;
-                break;
-        }
-
+        let basePrice = GameConstants.ItemPrice[GameConstants.BattleItemType[type]];
         let priceMultiplier = 1;
         super(GameConstants.BattleItemType[type], basePrice, priceMultiplier, GameConstants.Currency.money);
         this.type = type;

--- a/src/scripts/items/EggItem.ts
+++ b/src/scripts/items/EggItem.ts
@@ -3,7 +3,7 @@ class EggItem extends Item {
     type: GameConstants.EggItemType;
 
     constructor(type: GameConstants.EggItemType) {
-        let basePrice = 1000;
+        let basePrice = GameConstants.ItemPrice.Egg;
         let priceMultiplier = 1;
         super(GameConstants.EggItemType[type], basePrice, priceMultiplier, GameConstants.Currency.money);
         this.type = type;

--- a/src/scripts/items/EnergyRestore.ts
+++ b/src/scripts/items/EnergyRestore.ts
@@ -4,7 +4,7 @@ class EnergyRestore extends Item {
     type: GameConstants.EnergyRestoreSize;
 
     constructor(type: GameConstants.EnergyRestoreSize) {
-        let basePrice = 100;
+        let basePrice = GameConstants.ItemPrice[GameConstants.EnergyRestoreSize[type]];
         let priceMultiplier = 1;
         super(GameConstants.EnergyRestoreSize[type], basePrice, priceMultiplier, GameConstants.Currency.money);
         this.type = type;

--- a/src/scripts/items/EvolutionStone.ts
+++ b/src/scripts/items/EvolutionStone.ts
@@ -4,7 +4,7 @@ class EvolutionStone extends Item {
     type: GameConstants.StoneType;
 
     constructor(type: GameConstants.StoneType) {
-        let basePrice = 2500;
+        let basePrice = GameConstants.ItemPrice.EvolutionStone;
         let priceMultiplier = 1;
         super(GameConstants.StoneType[type], basePrice, priceMultiplier, GameConstants.Currency.questPoint);
         this.type = type;

--- a/src/scripts/items/PokeBlock.ts
+++ b/src/scripts/items/PokeBlock.ts
@@ -3,7 +3,7 @@ class PokeBlock extends Item {
     type: GameConstants.PokeBlockColor;
 
     constructor(color: GameConstants.PokeBlockColor) {
-        let basePrice = 0;
+        let basePrice = GameConstants.ItemPrice.PokeBlock;
         let priceMultiplier = 1;
         super(name, basePrice, priceMultiplier, GameConstants.Currency.money);
         this.type = color;

--- a/src/scripts/items/Pokeball.ts
+++ b/src/scripts/items/Pokeball.ts
@@ -3,27 +3,7 @@ class Pokeball extends Item {
     type: GameConstants.Pokeball;
 
     constructor(type: GameConstants.Pokeball) {
-
-        let basePrice = 0;
-        switch (type) {
-            case GameConstants.Pokeball.Pokeball: {
-                basePrice = GameConstants.ItemPrice.Pokeball;
-                break;
-            }
-            case GameConstants.Pokeball.Greatball: {
-                basePrice = GameConstants.ItemPrice.Greatball;
-                break;
-            }
-            case GameConstants.Pokeball.Ultraball: {
-                basePrice = GameConstants.ItemPrice.Ultraball;
-                break;
-            }
-            case GameConstants.Pokeball.Masterball: {
-                basePrice = GameConstants.ItemPrice.Masterball;
-                break;
-            }
-        }
-
+        let basePrice = GameConstants.ItemPrice[GameConstants.Pokeball[type]];
         let priceMultiplier = 1;
         super(GameConstants.Pokeball[type], basePrice, priceMultiplier, GameConstants.Currency.money);
         this.type = type;

--- a/src/scripts/items/PokemonItem.ts
+++ b/src/scripts/items/PokemonItem.ts
@@ -3,31 +3,7 @@ class PokemonItem extends Item {
     type: GameConstants.PokemonItemType;
 
     constructor(pokemon: GameConstants.PokemonItemType) {
-        let basePrice = 0;
-
-        switch (pokemon) {
-            case GameConstants.PokemonItemType.Eevee: {
-                basePrice = GameConstants.ItemPrice.Eevee;
-                break;
-            }
-            case GameConstants.PokemonItemType.Porygon: {
-                basePrice = GameConstants.ItemPrice.Porygon;
-                break;
-            }
-            case GameConstants.PokemonItemType.Jynx: {
-                basePrice = GameConstants.ItemPrice.Jynx;
-                break;
-            }
-            case GameConstants.PokemonItemType.Mr_Mime: {
-                basePrice = GameConstants.ItemPrice.Mr_Mime;
-                break;
-            }
-            case GameConstants.PokemonItemType.Lickitung: {
-                basePrice = GameConstants.ItemPrice.Lickitung;
-                break;
-            }
-        }
-
+        let basePrice = GameConstants.ItemPrice[GameConstants.PokemonItemType[pokemon]];
         let priceMultiplier = 1;
         super(GameConstants.PokemonItemType[pokemon], basePrice, priceMultiplier, GameConstants.Currency.questPoint);
         this.type = pokemon;

--- a/src/scripts/items/Vitamin.ts
+++ b/src/scripts/items/Vitamin.ts
@@ -3,7 +3,7 @@ class Vitamin extends Item {
     type: GameConstants.VitaminType;
 
     constructor(type: GameConstants.VitaminType) {
-        let basePrice = 0;
+        let basePrice = GameConstants.ItemPrice[GameConstants.VitaminType[type]];
         let priceMultiplier = 1;
         super(GameConstants.VitaminType[type], basePrice, priceMultiplier, GameConstants.Currency.money);
         this.type = type;

--- a/src/scripts/items/buyKeyItem.ts
+++ b/src/scripts/items/buyKeyItem.ts
@@ -2,8 +2,8 @@ class buyKeyItem extends Item {
     
         type: GameConstants.KeyItemType;
     
-        constructor(type: GameConstants.KeyItemType, price: number = 1000) {
-            let basePrice = price;
+        constructor(type: GameConstants.KeyItemType) {
+            let basePrice = GameConstants.ItemPrice[GameConstants.KeyItemType[type]];
             let priceMultiplier = 1;
             super(GameConstants.KeyItemType[type], basePrice, priceMultiplier, GameConstants.Currency.questPoint);
             this.type = type;
@@ -19,4 +19,4 @@ class buyKeyItem extends Item {
     }
     
     
-    ItemList['Dungeon_ticket'] = new buyKeyItem(GameConstants.KeyItemType.Dungeon_ticket, 250);
+    ItemList['Dungeon_ticket'] = new buyKeyItem(GameConstants.KeyItemType.Dungeon_ticket);


### PR DESCRIPTION
Refactor all shop prices into `GameConstants.ItemPrice`. 

For each subclass of `Item`, have the `ItemPrice` dictionary keys be the same as the item's enum names. This enables prices to be set in the following pattern: `GameConstants.ItemPrice[GameConstants.Pokeball[type]]`. No more switch statements!

I have not changed any item prices.

Closes #281 