### PR TITLE
Mark key item in shop as sold out after buying

### DIFF
--- a/src/components/shopView.html
+++ b/src/components/shopView.html
@@ -1,16 +1,21 @@
 <div id="shopView"
      data-bind="if: Game.gameState() === GameConstants.GameState.shop">
 <div class="row justify-content-center" data-bind="foreach: ShopHandler.shopObservable().items">
-   <div class="col-sm-3"  data-bind="visible: ShopHandler.ownKeyItem(name())">
+   <div class="col-sm-3">
        <div
                data-bind="click: function() {ShopHandler.setSelected($index())}, attr: {class: ShopHandler.calculateCss($index())}">
            <img src="" height="36px"
                 data-bind="attr:{ src: '/assets/images/items/' + name() + '.png' }">
            <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
            <p>
+               <div data-bind="if: ShopHandler.itemAvailable($data)">
                <img src="" class="currencyImage"
                     data-bind="attr:{ src: '/assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
                <span data-bind="text: totalPrice">Price</span>
+                </div>                
+                <div data-bind="ifnot: ShopHandler.itemAvailable($data)">
+                    <span>Sold Out</span>
+                </div>
            </p>
        </div>
    </div>

--- a/src/scripts/shop/ShopHandler.ts
+++ b/src/scripts/shop/ShopHandler.ts
@@ -26,6 +26,10 @@ class ShopHandler {
             return;
         }
         let item: Item = this.shopObservable().items()[ShopHandler.selected()];
+        if (!this.itemAvailable(item)) {
+            Notifier.notify(`${item.name()} is sold out!`, GameConstants.NotificationOption.danger)
+            return;
+        }
 
         let multiple = this.amount() > 1 ? "s" : "";
 
@@ -65,9 +69,10 @@ class ShopHandler {
         input.val(newVal > 1 ? newVal : 1).change();
     }
 
-    public static ownKeyItem(name: string): boolean {
-        let keyItem = GameConstants.KeyItemType[name];
-        return !(keyItem != undefined && player.hasKeyItem(name.replace("_", " ")));
+    public static itemAvailable(item: Item): boolean {
+        // Key items, when bought, are no longer available for purchase
+        // TODO: When using this function for if/ifnot binding on shopView, the binding does not update
+        return !((item instanceof buyKeyItem) && player.hasKeyItem(item.name().replace("_", " ")))
     }
 
     public static calculateCss(i: number): string {
@@ -81,7 +86,8 @@ class ShopHandler {
     public static calculateButtonCss(): string {
         let item: Item = this.shopObservable().items()[ShopHandler.selected()];
 
-        if (item && !player.hasCurrency(item.totalPrice(), item.currency) || this.amount() < 1) {
+        if (item && !(this.itemAvailable(item) && player.hasCurrency(item.totalPrice(), item.currency)) 
+                || this.amount() < 1) {
             return "btn btn-danger smallButton smallFont"
         } else {
             return "btn btn-success smallButton smallFont"


### PR DESCRIPTION
**Key items in shops**

**Current behavior**
After buying, the item stays in shop. If you re-enter the shop, the item is invisible but still selected.

**New behavior**
After buying, the item stays in shop, but purchase is no longer possible even if there is enough currency. An error message prints when attempting to buy again. Once you re-enter the shop, the item is marked as "Sold Out".

Attempt to buy when the shop is still open
![image](https://user-images.githubusercontent.com/36806183/58581352-5ac47e00-821d-11e9-89eb-6eb701ffc7d0.png)

Re-enter the shop: item is still selected but is sold out
![image](https://user-images.githubusercontent.com/36806183/58581392-70d23e80-821d-11e9-9596-689e59b2383e.png)

Marking as "Sold Out" as opposed to making invisible has the benefit that players can revisit the shop and know where the items are bought from. If item becomes invisible, players will forget where they bought it.

**Unresolved problem**
Immediately after buying, knockout's `if` binding doesn't kick in, so the key item isn't marked as Sold Out right away. It only gets marked as Sold Out after one re-enters the shop. I marked this as a TODO in `ShopHandler`.

**Save to test this change with**
[Pokeclicker save - shop key item test.txt](https://github.com/Ishadijcks/pokeclicker/files/3233929/Pokeclicker.save.-.shop.key.item.test.txt)

#291 