### PR TITLE
Use ISO date format to name save files

### DIFF
--- a/src/scripts/Save.ts
+++ b/src/scripts/Save.ts
@@ -23,12 +23,7 @@ class Save {
         let element = document.createElement('a');
         element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(btoa(JSON.stringify(player))));
         let currentdate = new Date();
-        let datetime = "" + currentdate.getDate() + "/"
-            + (currentdate.getMonth() + 1) + "/"
-            + currentdate.getFullYear() + " @ "
-            + currentdate.getHours() + ":"
-            + currentdate.getMinutes();
-        let filename = "Pokeclicker save - " + datetime + '.txt';
+        let filename = "PokeClickerSave_" + currentdate.toISOString() + '.txt';
         element.setAttribute('download', filename);
 
         element.style.display = 'none';

--- a/src/scripts/Save.ts
+++ b/src/scripts/Save.ts
@@ -23,7 +23,8 @@ class Save {
         let element = document.createElement('a');
         element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(btoa(JSON.stringify(player))));
         let currentdate = new Date();
-        let filename = "PokeClickerSave_" + currentdate.toISOString() + '.txt';
+        let datestr = currentdate.toISOString().replace("T", " ").slice(0, 19);
+        let filename = "PokeClickerSave_" + datestr + '.txt';
         element.setAttribute('download', filename);
 
         element.style.display = 'none';


### PR DESCRIPTION
Current save file names use DDMMYYYY.

ISO date format (YYYY-MM-DD HH-MM-SS) allows chronological sorting of save files on people's computers.

Closes #304 