### PR TITLE
shop keyitem fix

### DIFF
--- a/src/components/shopView.html
+++ b/src/components/shopView.html
@@ -1,7 +1,7 @@
 <div id="shopView"
      data-bind="if: Game.gameState() === GameConstants.GameState.shop">
 <div class="row justify-content-center" data-bind="foreach: ShopHandler.shopObservable().items">
-   <div class="col-sm-3"  data-bind="visible: ShopHandler.ownKeyItem(name())">
+   <div class="col-sm-3"  data-bind="hidden: ShopHandler.ownKeyItem(name())">
        <div
                data-bind="click: function() {ShopHandler.setSelected($index())}, attr: {class: ShopHandler.calculateCss($index())}">
            <img src="" height="36px"
@@ -63,5 +63,4 @@
             onClick="Game.gameState(GameConstants.GameState.town)">Return to Town
     </button>
 </div>
-    
 </div>

--- a/src/scripts/shop/ShopHandler.ts
+++ b/src/scripts/shop/ShopHandler.ts
@@ -33,7 +33,8 @@ class ShopHandler {
             player.payCurrency(item.totalPrice(), item.currency);
             item.buy(this.amount());
             item.increasePriceMultiplier(this.amount());
-            Notifier.notify("You bought " + this.amount() + " " + item.name() + multiple, GameConstants.NotificationOption.success)
+            Notifier.notify("You bought " + this.amount() + " " + item.name() + multiple, GameConstants.NotificationOption.success);
+            this.showShop(this.shopObservable());
         } else {
             let curr = "currency";
             switch (item.currency) {

--- a/src/scripts/shop/ShopHandler.ts
+++ b/src/scripts/shop/ShopHandler.ts
@@ -68,7 +68,7 @@ class ShopHandler {
 
     public static ownKeyItem(name: string): boolean {
         let keyItem = GameConstants.KeyItemType[name];
-        return !(keyItem != undefined && player.hasKeyItem(name.replace("_", " ")));
+        return keyItem != undefined && player.hasKeyItem(name.replace("_", " "));
     }
 
     public static calculateCss(i: number): string {


### PR DESCRIPTION
Alternative to #305, #307 & #310
Hides the dungeon token once it has been purchased.
Reversed the logic for `ownKeyItem`, now returns `true` when the player already owns the item.

closes #307 
closes #310 