### PR TITLE
Fix shop item background to cover the icon + cost numbers

### DIFF
--- a/src/components/shopView.html
+++ b/src/components/shopView.html
@@ -7,16 +7,14 @@
            <img src="" height="36px"
                 data-bind="attr:{ src: '/assets/images/items/' + name() + '.png' }">
            <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
-           <p>
-               <div data-bind="if: ShopHandler.itemAvailable($data)">
-               <img src="" class="currencyImage"
-                    data-bind="attr:{ src: '/assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
-               <span data-bind="text: totalPrice">Price</span>
-                </div>                
-                <div data-bind="ifnot: ShopHandler.itemAvailable($data)">
-                    <span>Sold Out</span>
-                </div>
-           </p>
+           <div data-bind="if: ShopHandler.itemAvailable($data)">
+                <img src="" class="currencyImage"
+                        data-bind="attr:{ src: '/assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
+                <span data-bind="text: totalPrice">Price</span>
+            </div>
+            <div data-bind="ifnot: ShopHandler.itemAvailable($data)">
+                <span>Sold Out</span>
+            </div>
        </div>
    </div>
 </div>


### PR DESCRIPTION
Fixed shop item background:
![image](https://user-images.githubusercontent.com/36806183/58596983-13051d00-8244-11e9-966c-ddb7e4a2d0c4.png)

Closes #308 