### PR TITLE
Update dungeon ticket description, Bold key item name

### DIFF
--- a/src/components/getKeyItem.html
+++ b/src/components/getKeyItem.html
@@ -15,8 +15,8 @@ aria-labelledby="keyItemModalLabel" aria-hidden="true">
                    class="key-item"
                    data-bind="attr:{ title: KeyItemHandler.getKeyItemByName(player.recentKeyItem()).name(),  src: 'assets/images/keyitems/' + KeyItemHandler.getKeyItemByName(player.recentKeyItem()).name() + '.png'}"
                    src=""/><br>
-           <span data-bind="text: KeyItemHandler.getKeyItemByName(player.recentKeyItem()).name()">Name</span><br>
-           <span data-bind="text: KeyItemHandler.getKeyItemByName(player.recentKeyItem()).description()">Description</span>
+           <span><strong data-bind="text: KeyItemHandler.getKeyItemByName(player.recentKeyItem()).name()">Name</strong></span><br>
+           <span data-bind="html: KeyItemHandler.getKeyItemByName(player.recentKeyItem()).description()">Description</span>
 
        </div>
        <div class="modal-footer">

--- a/src/index.html
+++ b/src/index.html
@@ -141,14 +141,14 @@
                                 </td>
                                 <td width="33.33%">
                                     <span style="display: inline;">
-                                        <img title="Dungeon Tokens" src="assets/images/currency/dungeonToken.png">
-                                        <span id="playerMoneyDungeon" data-bind="text: player.dungeonTokens">Not yet</span>
+                                        <img title="Dungeon Tokens&#013;&#010;Gained by capturing Pokemon" src="assets/images/currency/dungeonToken.png">
+                                        <span id="playerMoneyDungeon" data-bind="text: player.dungeonTokens">0</span>
                                     </span>
                                 </td>
                                 <td width="33.33%">
                                     <span style="display: inline;">
                                         <img title="Quest points" src="assets/images/currency/questPoint.png">
-                                        <span id="playerMoneyQuest" data-bind="text: player.questPoints">Not yet</span>
+                                        <span id="playerMoneyQuest" data-bind="text: player.questPoints">0</span>
                                     </span>
                                 </td>
                             </tr>

--- a/src/scripts/keyitems/KeyItemHandler.ts
+++ b/src/scripts/keyitems/KeyItemHandler.ts
@@ -20,7 +20,7 @@ class KeyItemHandler {
         // TODO obtain somewhere at the start
         KeyItemHandler.keyItemList.push(ko.observable(new KeyItem("Factory key", "This pass serves as an ID card for gaining access to the Pokéball factory that lies along Route 13")));
 
-        KeyItemHandler.keyItemList.push(ko.observable(new KeyItem("Dungeon ticket", "This ticket grants access to all dungeons in the Kanto region,<br/>You can gain more Dungeon Tokens by catching Pokémon")));
+        KeyItemHandler.keyItemList.push(ko.observable(new KeyItem("Dungeon ticket", "This ticket grants access to all dungeons in the Kanto region,<br/><strong>Tip:</strong> You gain Dungeon Tokens by capturing Pokémon")));
 
         // TODO obtain somewhere at the start
         KeyItemHandler.keyItemList.push(ko.observable(new KeyItem("Holo caster", "A device that allows users to receive and view hologram clips at any time. It’s also used to chat with others")));

--- a/src/scripts/keyitems/KeyItemHandler.ts
+++ b/src/scripts/keyitems/KeyItemHandler.ts
@@ -20,7 +20,7 @@ class KeyItemHandler {
         // TODO obtain somewhere at the start
         KeyItemHandler.keyItemList.push(ko.observable(new KeyItem("Factory key", "This pass serves as an ID card for gaining access to the Pokéball factory that lies along Route 13")));
 
-        KeyItemHandler.keyItemList.push(ko.observable(new KeyItem("Dungeon ticket", "This ticket grants access to all dungeons in the Kanto region")));
+        KeyItemHandler.keyItemList.push(ko.observable(new KeyItem("Dungeon ticket", "This ticket grants access to all dungeons in the Kanto region,<br/>You can gain more Dungeon Tokens by catching Pokémon")));
 
         // TODO obtain somewhere at the start
         KeyItemHandler.keyItemList.push(ko.observable(new KeyItem("Holo caster", "A device that allows users to receive and view hologram clips at any time. It’s also used to chat with others")));


### PR DESCRIPTION
Fixes #290 
Updated `Dungeon Token` title description,
Added how to gain dungeon tokens in the `Dungeon Ticket` description, Bolded key item name.
![Screenshot from 2019-05-30 11-34-53](https://user-images.githubusercontent.com/7288322/58598185-5062bc80-82cf-11e9-8a37-3bd517f7a2c6.png)
![Screenshot from 2019-05-30 11-40-03](https://user-images.githubusercontent.com/7288322/58598279-b7807100-82cf-11e9-8d96-14819165b048.png)
