### PR TITLE
Show shiny sprite for base form pokemon in Evo Stone menu

### DIFF
--- a/src/components/itemModal.html
+++ b/src/components/itemModal.html
@@ -65,9 +65,12 @@
                                         data-bind="if: (player.alreadyCaughtPokemon($data.name))">
                                         <button class="btn btn-secondary smallButton list-group-item-action" style="padding-right:15px"
                                                 data-bind="click: function() {ItemHandler.pokemonSelected(name)}, css:{ 'pokemon-selected': ItemHandler.pokemonSelected() === name}">
-                                            <img class="smallImage"
-                                                 data-bind="attr:{ src: '/assets/images/pokemon/' + id +'.png' }"
-                                                 src=""/>
+                                            <span data-bind="if: player.alreadyCaughtPokemonShiny($data.name)">
+                                                <img class="smallImage" data-bind="attr:{ src: '/assets/images/shinypokemon/' + id +'.png' }"/>
+                                            </span>
+                                            <span data-bind="ifnot: player.alreadyCaughtPokemonShiny($data.name)">
+                                                <img class="smallImage" data-bind="attr:{ src: '/assets/images/pokemon/' + id +'.png' }"/>
+                                            </span>
                                             <span data-bind="text: name" style="margin-left: 20px">Name</span>
 
                                             <span style="float:right; margin-top:8px"


### PR DESCRIPTION
In evolution stone menu, for base form Pokemon that player has caught shiny, fix to show the shiny sprite.

**Previous look:**
![image](https://user-images.githubusercontent.com/36806183/58742200-c6ab1000-83f0-11e9-95eb-571e31c5d643.png)

**New look:**
![image](https://user-images.githubusercontent.com/36806183/58742190-a67b5100-83f0-11e9-8c04-ae5773f77fe7.png)

(I have Shellder shiny)