### PR TITLE
Correct plot:hover css selector

### DIFF
--- a/src/styles/farm.less
+++ b/src/styles/farm.less
@@ -35,7 +35,7 @@
   padding-bottom: 20%;
   overflow: hidden;
 
-  :hover {
+  &:hover {
     filter: brightness(95%);
     -webkit-filter: brightness(95%);
     cursor: pointer;


### PR DESCRIPTION
```
.plot {
  :hover {
    thing: value;
  }
}
```
compiles to `.plot :hover`, ie every child of a `.plot` which is being hovered over.
Adding the `&` makes it compile to `.plot:hover`.

I have no idea why this fixes #294 , but it does.