### PR TITLE
Let oak item display name be humanified from enum name

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -534,7 +534,7 @@
                     <div>
                         <div>
                             <img class="clickable" src=""
-                                 data-bind="attr:{ src: '/assets/images/oakitems/' + $data.displayName() + '.png'},
+                                 data-bind="attr:{ src: '/assets/images/oakitems/' + GameConstants.humanifyString(GameConstants.OakItem[$data.id]) + '.png'},
                                   css: {'oak-item-small-selected': OakItemRunner.isActive($data.id),
                                         'oak-item-small': !OakItemRunner.isActive($data.id),
                                         'oak-item-locked': !OakItemRunner.isUnlocked($data.id)
@@ -556,7 +556,7 @@
                         <div class="row justify-content-sm-center">
                             <div style="height:20px;" class="col">
                                 <b>
-                                    <span data-bind="text: OakItemRunner.inspectedItem().displayName()"></span>
+                                    <span data-bind="text: GameConstants.humanifyString(GameConstants.OakItem[OakItemRunner.inspectedItem().id])"></span>
                                 </b>
                             </div>
                         </div>
@@ -604,7 +604,7 @@
                         <div class="row justify-content-sm-center">
                             <div style="height:20px;" class="col">
                                 <b>
-                                    <span data-bind="text: OakItemRunner.inspectedItem().displayName()"></span>
+                                    <span data-bind="text: GameConstants.humanifyString(GameConstants.OakItem[OakItemRunner.inspectedItem().id])"></span>
                                 </b>
                             </div>
                         </div>

--- a/src/scripts/Battle.ts
+++ b/src/scripts/Battle.ts
@@ -39,7 +39,7 @@ class Battle {
         if (!this.enemyPokemon().isAlive()) {
             return;
         }
-        OakItemRunner.use(GameConstants.OakItem.PoisonBarb);
+        OakItemRunner.use(GameConstants.OakItem.Poison_Barb);
         GameHelper.incrementObservable(player.statistics.clicks)
         this.enemyPokemon().damage(player.calculateClickAttack());
         if (!this.enemyPokemon().isAlive()) {
@@ -90,8 +90,8 @@ class Battle {
 
     protected static calculateActualCatchRate(pokeBall: GameConstants.Pokeball) {
         let pokeballBonus = GameConstants.getCatchBonus(pokeBall);
-        let oakBonus = OakItemRunner.isActive(GameConstants.OakItem.MagicBall) ? 
-            OakItemRunner.calculateBonus(GameConstants.OakItem.MagicBall) : 0;
+        let oakBonus = OakItemRunner.isActive(GameConstants.OakItem.Magic_Ball) ? 
+            OakItemRunner.calculateBonus(GameConstants.OakItem.Magic_Ball) : 0;
         let totalChance = this.enemyPokemon().catchRate + pokeballBonus + oakBonus;
         return totalChance;
     }

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -110,14 +110,14 @@ namespace GameConstants {
     }
 
     export enum OakItem {
-        MagicBall = 0,
-        AmuletCoin,
-        PoisonBarb,
-        ExpShare,
+        Magic_Ball = 0,
+        Amulet_Coin,
+        Poison_Barb,
+        Exp_Share,
         Sprayduck,
-        ShinyCharm,
-        BlazeCassette,
-        CellBattery,
+        Shiny_Charm,
+        Blaze_Cassette,
+        Cell_Battery,
     }
 
     // Dungeons

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -318,7 +318,7 @@ class Player {
     private _caughtAmount: Array<KnockoutObservable<number>>;
 
     public calculateClickAttack(): number {
-        let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.PoisonBarb) ? (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.PoisonBarb) / 100) : 1;
+        let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.Poison_Barb) ? (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.Poison_Barb) / 100) : 1;
         return Math.floor(Math.pow(this.caughtPokemonList.length + 1, 1.4) * oakItemBonus);
     }
 
@@ -403,7 +403,7 @@ class Player {
     }
 
     public capturePokemon(pokemonName: string, shiny: boolean = false, supressNotification = false) {
-        OakItemRunner.use(GameConstants.OakItem.MagicBall);
+        OakItemRunner.use(GameConstants.OakItem.Magic_Ball);
         let pokemonData = PokemonHelper.getPokemonByName(pokemonName);
         if (!this.alreadyCaughtPokemon(pokemonName)) {
             let caughtPokemon: CaughtPokemon = new CaughtPokemon(pokemonData, false, 0, 0);
@@ -436,9 +436,9 @@ class Player {
     }
 
     public gainMoney(money: number) {
-        OakItemRunner.use(GameConstants.OakItem.AmuletCoin);
+        OakItemRunner.use(GameConstants.OakItem.Amulet_Coin);
         // TODO add money multipliers
-        let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.AmuletCoin) ? (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.AmuletCoin) / 100) : 1;
+        let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.Amulet_Coin) ? (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.Amulet_Coin) / 100) : 1;
         let moneytogain = Math.floor(money * oakItemBonus * (1 + AchievementHandler.achievementBonus()))
         this._money(this._money() + moneytogain);
         GameHelper.incrementObservable(this.statistics.totalMoney, moneytogain);
@@ -521,10 +521,10 @@ class Player {
     }
 
     public gainExp(exp: number, level: number, trainer: boolean) {
-        OakItemRunner.use(GameConstants.OakItem.ExpShare);
+        OakItemRunner.use(GameConstants.OakItem.Exp_Share);
         // TODO add exp multipliers
         let trainerBonus = trainer ? 1.5 : 1;
-        let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.ExpShare) ? 1 + (OakItemRunner.calculateBonus(GameConstants.OakItem.ExpShare) / 100) : 1;
+        let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.Exp_Share) ? 1 + (OakItemRunner.calculateBonus(GameConstants.OakItem.Exp_Share) / 100) : 1;
         let expTotal = Math.floor(exp * level * trainerBonus * oakItemBonus * (1 + AchievementHandler.achievementBonus()) / 9);
 
         for (let pokemon of this._caughtPokemonList()) {

--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -13,8 +13,8 @@ class BreedingHelper {
     }
 
     public static progressEggs(amount: number) {
-        if (OakItemRunner.isActive(GameConstants.OakItem.BlazeCassette)) {
-            amount *= (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.BlazeCassette) / 100)
+        if (OakItemRunner.isActive(GameConstants.OakItem.Blaze_Cassette)) {
+            amount *= (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.Blaze_Cassette) / 100)
         }
         amount = Math.round(amount);
         for (let obj of player.eggList) {
@@ -23,7 +23,7 @@ class BreedingHelper {
                 continue;
             }
             egg.steps(egg.steps() + amount);
-            if (OakItemRunner.isActive(GameConstants.OakItem.ShinyCharm)) {
+            if (OakItemRunner.isActive(GameConstants.OakItem.Shiny_Charm)) {
                 egg.shinySteps += amount;
             }
             if (egg.steps() >= egg.totalSteps) {
@@ -64,7 +64,7 @@ class BreedingHelper {
         player.capturePokemon(egg.pokemon, shiny);
         player._eggList[index](null);
         GameHelper.incrementObservable(player.statistics.hatchedEggs);
-        OakItemRunner.use(GameConstants.OakItem.BlazeCassette);
+        OakItemRunner.use(GameConstants.OakItem.Blaze_Cassette);
     }
 
     public static createEgg(pokemonName: string, type = GameConstants.EggType.Pokemon): Egg {

--- a/src/scripts/oakitems/OakItem.ts
+++ b/src/scripts/oakitems/OakItem.ts
@@ -1,6 +1,5 @@
 class OakItem {
     public id: GameConstants.OakItem;
-    public displayName: KnockoutObservable<string>;
     public unlockReq: number;
     public description: KnockoutObservable<string>;
     public baseBonus: number;
@@ -9,9 +8,8 @@ class OakItem {
     public level: KnockoutObservable<number>;
     public isActive: KnockoutObservable<boolean>;
 
-    constructor(id: GameConstants.OakItem, displayName: string, unlockReq: number, description: string, baseBonus: number, stepBonus: number, expGain: number) {
+    constructor(id: GameConstants.OakItem, unlockReq: number, description: string, baseBonus: number, stepBonus: number, expGain: number) {
         this.id = id;
-        this.displayName = ko.observable(displayName);
         this.unlockReq = unlockReq;
         this.description = ko.observable(description);
         this.baseBonus = baseBonus;

--- a/src/scripts/oakitems/OakItemRunner.ts
+++ b/src/scripts/oakitems/OakItemRunner.ts
@@ -2,35 +2,35 @@ class OakItemRunner {
 
     public static oakItemList: KnockoutObservable<OakItem>[];
     // public static blankOakItem: OakItem = new OakItem(" ", Number.MAX_VALUE, "", 0, 0, 0);
-    public static inspectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 20, "Gives a bonus to your catchrate", 5, 1, 2));
-    public static selectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 20, "Gives a bonus to your catchrate", 5, 1, 2));
+    public static inspectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.Magic_Ball, 20, "Gives a bonus to your catchrate", 5, 1, 2));
+    public static selectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.Magic_Ball, 20, "Gives a bonus to your catchrate", 5, 1, 2));
 
     public static initialize() {
         OakItemRunner.oakItemList = [];
 
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 20, "Gives a bonus to your catchrate", 5, 1, 2)));
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.AmuletCoin, "Amulet Coin", 30, "Gain more coins from battling", 25, 5, 1)));
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.PoisonBarb, "Poison Barb", 40, "Clicks do more damage", 25, 5, 3)));
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.ExpShare, "Exp Share", 50, "Gain more exp from battling", 15, 3, 1)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Magic_Ball, 20, "Gives a bonus to your catchrate", 5, 1, 2)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Amulet_Coin, 30, "Gain more coins from battling", 25, 5, 1)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Poison_Barb, 40, "Clicks do more damage", 25, 5, 3)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Exp_Share, 50, "Gain more exp from battling", 15, 3, 1)));
 
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Sprayduck, "Sprayduck", 60, "Makes your berries grow faster", 25, 5, 3    )));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Sprayduck, 60, "Makes your berries grow faster", 25, 5, 3    )));
 
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.ShinyCharm, "Shiny Charm", 70, "Encounter more shinies", 50, 100, 150)));
-
-        // TODO implement use!
-        // TODO implement functionality
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.BlazeCassette, "Blaze Cassette", 80, "Hatch eggs faster", 50, 10, 10)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Shiny_Charm, 70, "Encounter more shinies", 50, 100, 150)));
 
         // TODO implement use!
         // TODO implement functionality
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.CellBattery, "Cell Battery", 90, "Regenerate more mining energy", 25, 5, 4)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Blaze_Cassette, 80, "Hatch eggs faster", 50, 10, 10)));
+
+        // TODO implement use!
+        // TODO implement functionality
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Cell_Battery, 90, "Regenerate more mining energy", 25, 5, 4)));
 
         // OakItemRunner.oakItemList must preserve the ordering of items in GameConstants.OakItem enum
         if (!OakItemRunner.oakItemList.every((f, i)=>f().id==i)) {
             throw new Error("Oak items are out of order!")
         }
 
-        let item: OakItem = OakItemRunner.getOakItemObject(GameConstants.OakItem.MagicBall);
+        let item: OakItem = OakItemRunner.getOakItemObject(GameConstants.OakItem.Magic_Ball);
         OakItemRunner.selectedItem(item);
     }
 

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -50,13 +50,13 @@ class PokemonFactory {
      * @returns {boolean}
      */
     public static generateShiny(chance: number): boolean {
-        chance = OakItemRunner.isActive(GameConstants.OakItem.ShinyCharm) ? chance / (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.ShinyCharm) / 100) : chance;
+        chance = OakItemRunner.isActive(GameConstants.OakItem.Shiny_Charm) ? chance / (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.Shiny_Charm) / 100) : chance;
 
         let rand: number = Math.floor(Math.random() * chance) + 1;
 
         if (rand <= 1) {
             Notifier.notify("You encounter a shiny Pokémon...", GameConstants.NotificationOption.warning);
-            OakItemRunner.use(GameConstants.OakItem.ShinyCharm);
+            OakItemRunner.use(GameConstants.OakItem.Shiny_Charm);
             return true;
         }
         return false;

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -64,14 +64,14 @@ class QuestHelper{
                 return new UsePokeballQuest(pokeball, amount);
             case "UseOakItem":
                 let possibleItems = [
-                    GameConstants.OakItem.MagicBall,
-                    GameConstants.OakItem.AmuletCoin,
-                    //GameConstants.OakItem.PoisonBarb,
-                    GameConstants.OakItem.ExpShare,
+                    GameConstants.OakItem.Magic_Ball,
+                    GameConstants.OakItem.Amulet_Coin,
+                    //GameConstants.OakItem.Poison_Barb,
+                    GameConstants.OakItem.Exp_Share,
                     //GameConstants.OakItem.Sprayduck,
-                    //GameConstants.OakItem.ShinyCharm,
-                    //GameConstants.OakItem.BlazeCassette,
-                    //GameConstants.OakItem.CellBattery,
+                    //GameConstants.OakItem.Shiny_Charm,
+                    //GameConstants.OakItem.Blaze_Cassette,
+                    //GameConstants.OakItem.Cell_Battery,
                 ]
                 let oakItem = SeededRand.fromArray(possibleItems);
                 amount = SeededRand.intBetween(100, 500);

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -99,8 +99,8 @@ class Underground {
     public static gainEnergy() {
         if (player._mineEnergy() < player._maxMineEnergy()) {
             let multiplier = 1;
-            if(OakItemRunner.isActive(GameConstants.OakItem.CellBattery)){
-                multiplier += (OakItemRunner.calculateBonus(GameConstants.OakItem.CellBattery) / 100);
+            if(OakItemRunner.isActive(GameConstants.OakItem.Cell_Battery)){
+                multiplier += (OakItemRunner.calculateBonus(GameConstants.OakItem.Cell_Battery) / 100);
             }
             player._mineEnergy( Math.min(player._maxMineEnergy(), player._mineEnergy() + (multiplier*player.mineEnergyGain)) );
             if(player._mineEnergy() === player._maxMineEnergy()){


### PR DESCRIPTION
Another refactor of Oak items. This time to avoid hard-coding all the display names, and instead use `GameConstants.humanifyString` on slightly modified enum names.