### PR TITLE
Implement energy restore items

### DIFF
--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -547,9 +547,9 @@ namespace GameConstants {
         "Item_magnet": 1500,
         "Lucky_incense": 2000,
 
-        "SmallRestore": 100,
-        "MediumRestore": 100,
-        "LargeRestore": 100,
+        "SmallRestore": 20000,
+        "MediumRestore": 40000,
+        "LargeRestore": 100000,
 
         "PokeBlock": 0,
 
@@ -653,6 +653,12 @@ namespace GameConstants {
         Pokemon,
         Mystery,
         Fossil
+    }
+
+    export const EnergyRestoreEffect = {
+        SmallRestore: 0.1,
+        MediumRestore: 0.2,
+        LargeRestore: 0.5,
     }
 
     export const KeyToDirection = {

--- a/src/scripts/items/EnergyRestore.ts
+++ b/src/scripts/items/EnergyRestore.ts
@@ -11,9 +11,19 @@ class EnergyRestore extends Item {
     }
 
     buy(amt: number) {
+        this._increaseCount(amt);
     }
 
     use() {
+        if (player.itemList[this.name()]() <= 0) {
+            return;
+        }
+        if (player._mineEnergy() === player._maxMineEnergy()) {
+            Notifier.notify("Your mining energy is already full!", GameConstants.NotificationOption.danger);
+            return;
+        }
+        Underground.gainEnergyThroughItem(this.type);
+        this._decreaseCount(1);
     }
 }
 

--- a/src/scripts/oakitems/OakItemRunner.ts
+++ b/src/scripts/oakitems/OakItemRunner.ts
@@ -23,7 +23,7 @@ class OakItemRunner {
 
         // TODO implement use!
         // TODO implement functionality
-        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Cell_Battery, 90, "Regenerate more mining energy", 25, 5, 4)));
+        OakItemRunner.oakItemList.push(ko.observable(new OakItem(GameConstants.OakItem.Cell_Battery, 90, "More passive mining energy regen", 25, 5, 4)));
 
         // OakItemRunner.oakItemList must preserve the ordering of items in GameConstants.OakItem enum
         if (!OakItemRunner.oakItemList.every((f, i)=>f().id==i)) {

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -109,6 +109,14 @@ class Underground {
         }
     }
 
+    public static gainEnergyThroughItem(item: GameConstants.EnergyRestoreSize) {
+        // Restore a percentage of maximum energy
+        let effect: number = GameConstants.EnergyRestoreEffect[GameConstants.EnergyRestoreSize[item]];
+        let gain = Math.min(player._maxMineEnergy() - player._mineEnergy(), effect * player._maxMineEnergy());
+        player._mineEnergy(player._mineEnergy() + gain);
+        Notifier.notify("You restored " + gain + " mining energy!", GameConstants.NotificationOption.success);
+    }
+
     public static sellMineItem(id: number) {
         for (let i=0; i<player._mineInventory().length; i++) {
             let item = player._mineInventory()[i];


### PR DESCRIPTION
Energy restore costs money and restores a certain percentage of player's maximum mine energy, unaffected by Cell Battery. Cell battery's tool tip was updated to reflect this information.

Usage fails if energy is already full, with an error message. A success message prints if the restore was successful, with the actual restored amount.

![image](https://user-images.githubusercontent.com/36806183/58750586-4f15c900-8462-11e9-85e2-5d52452f9bbf.png)

![image](https://user-images.githubusercontent.com/36806183/58750598-7371a580-8462-11e9-980b-88d3aef7b01c.png)

**Balancing thoughts**
This is very preliminary. For small restore (10% max energy), with base mine stats, 5 energy = 100 seconds passive regen. On the routes, 100 seconds ~ 20K money (200 per second). So small restore costs 20K. 

Medium/Large restore prices scale according to their effect. But the benefit here is, player doesn't have to buy as many to achieve the same effect, hence reducing cost.

**Testing**
`player.gainKeyItem("Explorer kit") // Give you access to the mine`
`ItemList['SmallRestore']._increaseCount(100) // Give yourself some restore items`
`ItemList['SmallRestore'].use()`