### PR TITLE
Set min height of images

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -200,7 +200,7 @@
 
                             <div>
                                 <div data-bind="ifnot: Battle.catching">
-                                    <img class="clickable" id="enemy" style="min-height:96px;"
+                                    <img class="clickable" id="enemy"
                                          data-bind="click: function() {Battle.clickAttack()},
                                                     attr:{ src: PokemonHelper.getImage(Battle.enemyPokemon(), Battle.enemyPokemon().shiny) }"
                                          src=""/>
@@ -210,7 +210,7 @@
                                     <span data-bind="text: Battle.enemyPokemon().maxHealth">maxHealth</span>
                                 </div>
                                 <div data-bind="if: Battle.catching">
-                                    <img class="pokeball-animated" style="min-height:96px;"
+                                    <img class="pokeball-animated"
                                          data-bind="attr:{ src: '/assets/images/pokeball/' + GameConstants.Pokeball[Battle.pokeball()] + '.png' }"
                                          src=""/>
                                     <br>
@@ -271,7 +271,7 @@
 
                                 <div>
                                     <div data-bind="ifnot: DungeonBattle.catching">
-                                        <img id="dungeonEnemy" style="min-height:96px;"
+                                        <img id="dungeonEnemy"
                                              data-bind="click: function() {DungeonBattle.clickAttack()}, attr:{ src: PokemonHelper.getImage(DungeonBattle.enemyPokemon(), DungeonBattle.enemyPokemon().shiny) }"
                                              src=""/>
                                         <br>
@@ -279,7 +279,7 @@
                                         <span data-bind="text: DungeonBattle.enemyPokemon().maxHealth">maxHealth</span>
                                     </div>
                                     <div data-bind="if: DungeonBattle.catching">
-                                        <img class="pokeball-animated" style="min-height:96px;"
+                                        <img class="pokeball-animated"
                                              data-bind="attr:{ src: '/assets/images/pokeball/' + GameConstants.Pokeball[DungeonBattle.pokeball()] + '.png' }"
                                              src=""/>
                                         <br>

--- a/src/index.html
+++ b/src/index.html
@@ -200,7 +200,7 @@
 
                             <div>
                                 <div data-bind="ifnot: Battle.catching">
-                                    <img class="clickable" id="enemy"
+                                    <img class="clickable" id="enemy" style="min-height:96px;"
                                          data-bind="click: function() {Battle.clickAttack()},
                                                     attr:{ src: PokemonHelper.getImage(Battle.enemyPokemon(), Battle.enemyPokemon().shiny) }"
                                          src=""/>
@@ -210,7 +210,7 @@
                                     <span data-bind="text: Battle.enemyPokemon().maxHealth">maxHealth</span>
                                 </div>
                                 <div data-bind="if: Battle.catching">
-                                    <img class="pokeball-animated"
+                                    <img class="pokeball-animated" style="min-height:96px;"
                                          data-bind="attr:{ src: '/assets/images/pokeball/' + GameConstants.Pokeball[Battle.pokeball()] + '.png' }"
                                          src=""/>
                                     <br>
@@ -271,7 +271,7 @@
 
                                 <div>
                                     <div data-bind="ifnot: DungeonBattle.catching">
-                                        <img id="dungeonEnemy"
+                                        <img id="dungeonEnemy" style="min-height:96px;"
                                              data-bind="click: function() {DungeonBattle.clickAttack()}, attr:{ src: PokemonHelper.getImage(DungeonBattle.enemyPokemon(), DungeonBattle.enemyPokemon().shiny) }"
                                              src=""/>
                                         <br>
@@ -279,7 +279,7 @@
                                         <span data-bind="text: DungeonBattle.enemyPokemon().maxHealth">maxHealth</span>
                                     </div>
                                     <div data-bind="if: DungeonBattle.catching">
-                                        <img class="pokeball-animated"
+                                        <img class="pokeball-animated" style="min-height:96px;"
                                              data-bind="attr:{ src: '/assets/images/pokeball/' + GameConstants.Pokeball[DungeonBattle.pokeball()] + '.png' }"
                                              src=""/>
                                         <br>

--- a/src/styles/dungeon.less
+++ b/src/styles/dungeon.less
@@ -58,3 +58,7 @@
   margin: -10px -10px -12px;
 
 }
+
+#dungeonEnemy {
+  min-height: 96px;
+}

--- a/src/styles/gyms.less
+++ b/src/styles/gyms.less
@@ -36,3 +36,7 @@
   width: 100%;
   height: 100%;
 }
+
+#gymEnemy {
+  min-height: 96px;
+}

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -256,3 +256,7 @@ img {
 #saveTab2 input {
   display:none;
 }
+
+#enemy {
+  min-height: 96px;
+}

--- a/src/styles/pokeball.less
+++ b/src/styles/pokeball.less
@@ -1,4 +1,5 @@
 .pokeball-animated {
+  min-height: 96px;
   -webkit-animation:spin 1s linear infinite;
   -moz-animation:spin 1s linear infinite;
   animation:spin 1s linear infinite;


### PR DESCRIPTION
Alternative to #334 
Have set the minimum height of the pokeball & pokemon images, this should eliminate the jumping that occours when an image has to be loaded.

closes #333 
closes #334 