### PR TITLE
Update itemModal.html

### DIFF
--- a/src/components/itemModal.html
+++ b/src/components/itemModal.html
@@ -169,7 +169,7 @@
                                         <div class="col-sm-11">
                                             <div data-bind="if: KeyItemHandler.inspectedItem().isUnlocked()">
                                                 <p style="margin-top: 5px"
-                                                   data-bind="text: KeyItemHandler.inspectedItem().description"></p>
+                                                   data-bind="html: KeyItemHandler.inspectedItem().description"></p>
                                             </div>
                                             <div data-bind="ifnot: KeyItemHandler.inspectedItem().isUnlocked()">
                                                 <p style="margin-top: 5px">?????</p>


### PR DESCRIPTION
Html elements in item descriptions are now supported in the itemModel. The main improvement of this is that the Dungeon Ticket's description will display properly now.
Before:
![Before](https://user-images.githubusercontent.com/7018593/58894170-575e4600-86a6-11e9-9c68-21c8aee66681.PNG)
After:
![After](https://user-images.githubusercontent.com/7018593/58894182-5decbd80-86a6-11e9-9d9c-04731078857b.PNG)

