### PR TITLE
Lower memory usage

### DIFF
--- a/src/components/JohtoSVG.html
+++ b/src/components/JohtoSVG.html
@@ -14,18 +14,18 @@
     <path class="city" data-town="TOWN"
           data-bind="
           click:function(){MapHelper.moveToTown('TOWN')},
-          attr: { class: MapHelper.calculateTownCssClass('TOWN')() }"
+          attr: { class: MapHelper.calculateTownCssClass('TOWN') }"
           d="M 72.8 109.53 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
     </path>
-    
+
     -->
 
     <!--Route 26-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(26, 1); } ">
         <rect data-route='26'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(26,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(26,1) }"
               height="31"
               width="135"
               x="512" y="277"></rect>
@@ -36,7 +36,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(27, 1); } ">
         <rect data-route='27'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(27,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(27,1) }"
               height="31"
               width="208"
               x="-110" y="-300"></rect>
@@ -46,7 +46,7 @@
     <!--Route 28-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(28, 1); } ">
         <rect data-route='28'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(28,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(28,1) }"
               height="31"
               width="92"
               x="525" y="216"></rect>
@@ -56,7 +56,7 @@
     <!--Route 29-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(29, 1); } ">
         <rect data-route='29'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(29,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(29,1) }"
               height="31"
               width="143"
               x="368" y="277"></rect>
@@ -67,7 +67,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(30, 1); } ">
         <rect data-route='30'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(30,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(30,1) }"
               height="31"
               width="150"
               x="-25" y="-24"></rect>
@@ -77,7 +77,7 @@
     <!--Route 31-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(31, 1); } ">
         <rect data-route='31'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(31,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(31,1) }"
               height="31"
               width="67"
               x="304" y="124"></rect>
@@ -88,7 +88,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(32, 1); } ">
         <rect data-route='32'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(32,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(32,1) }"
               height="31"
               width="217"
               x="-25" y="37"></rect>
@@ -98,7 +98,7 @@
     <!--Route 33-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(33, 1); } ">
         <rect data-route='33'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(33,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(33,1) }"
               height="31"
               width="100"
               x="209" y="369"></rect>
@@ -109,7 +109,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(34, 1); } ">
         <rect data-route='34'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(34,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(34,1) }"
               height="31"
               width="127"
               x="92" y="160"></rect>
@@ -120,7 +120,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(35, 1); } ">
         <rect data-route='35'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(35,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(35,1) }"
               height="31"
               width="73"
               x="-25" y="160"></rect>
@@ -130,7 +130,7 @@
     <!--Route 36-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(36, 1); } ">
         <rect data-route='36'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(36,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(36,1) }"
               height="31"
               width="131"
               x="156" y="124"></rect>
@@ -140,7 +140,7 @@
     <!--Route 37-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(37, 1); } ">
         <rect data-route='37'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(37,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(37,1) }"
               height="38"
               width="31"
               x="216" y="87"></rect>
@@ -150,7 +150,7 @@
     <!--Route 38-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(38, 1); } ">
         <rect data-route='38'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(38,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(38,1) }"
               height="31"
               width="95"
               x="124" y="62"></rect>
@@ -161,7 +161,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(39, 1); } ">
         <rect data-route='39'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(39,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(39,1) }"
               height="31"
               width="65"
               x="-117" y="222"></rect>
@@ -172,7 +172,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(40, 1); } ">
         <rect data-route='40'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(40,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(40,1) }"
               height="31"
               width="70"
               x="-25" y="252"></rect>
@@ -183,7 +183,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(41, 1); } ">
         <rect data-route='41'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(41,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(41,1) }"
               height="31"
               width="84"
               x="45" y="252"></rect>
@@ -193,7 +193,7 @@
     <!--Route 42-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(42, 1); } ">
         <rect data-route='42'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(42,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(42,1) }"
               height="31"
               width="136"
               x="242" y="62"></rect>
@@ -204,7 +204,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(43, 1); } ">
         <rect data-route='43'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(43,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(43,1) }"
               height="31"
               width="63"
               x="-180" y="-55"></rect>
@@ -214,7 +214,7 @@
     <!--Route 44-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(44, 1); } ">
         <rect data-route='44'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(44,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(44,1) }"
               height="31"
               width="99"
               x="397" y="62"></rect>
@@ -225,7 +225,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(45, 1); } ">
         <rect data-route='45'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(45,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(45,1) }"
               height="31"
               width="100"
               x="-62" y="-148"></rect>
@@ -236,7 +236,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(46, 1); } ">
         <rect data-route='46'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(46,1)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(46,1) }"
               height="31"
               width="94"
               x="6" y="-117"></rect>
@@ -250,7 +250,7 @@
     <path class="city" data-town="New Bark Town"
           data-bind="
           click:function(){MapHelper.moveToTown('New Bark Town')},
-          attr: { class: MapHelper.calculateTownCssClass('New Bark Town')() }"
+          attr: { class: MapHelper.calculateTownCssClass('New Bark Town') }"
           d="M 498.8 287.53 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -263,7 +263,7 @@
     <path class="city" data-town="Cherrygrove City"
           data-bind="
           click:function(){MapHelper.moveToTown('Cherrygrove City')},
-          attr: { class: MapHelper.calculateTownCssClass('Cherrygrove City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Cherrygrove City') }"
           d="M 342.8 289.53 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -276,7 +276,7 @@
     <path class="city" data-town="Violet City"
           data-bind="
           click:function(){MapHelper.moveToTown('Violet City')},
-          attr: { class: MapHelper.calculateTownCssClass('Violet City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Violet City') }"
           d="M 283.8 134.53 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -289,7 +289,7 @@
     <path class="city" data-town="Azalea Town"
           data-bind="
           click:function(){MapHelper.moveToTown('Azalea Town')},
-          attr: { class: MapHelper.calculateTownCssClass('Azalea Town')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Azalea Town') }"
           d="M 189.8 379.53 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -302,7 +302,7 @@
     <path class="city" data-town="Goldenrod City"
           data-bind="
           click:function(){MapHelper.moveToTown('Goldenrod City')},
-          attr: { class: MapHelper.calculateTownCssClass('Goldenrod City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Goldenrod City') }"
           d="M 160.8 230.14 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 38 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -315,7 +315,7 @@
     <path class="city" data-town="Ecruteak City"
           data-bind="
           click:function(){MapHelper.moveToTown('Ecruteak City')},
-          attr: { class: MapHelper.calculateTownCssClass('Ecruteak City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Ecruteak City') }"
           d="M 220.8 73 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -328,7 +328,7 @@
     <path class="city" data-town="Olivine City"
           data-bind="
           click:function(){MapHelper.moveToTown('Olivine City')},
-          attr: { class: MapHelper.calculateTownCssClass('Olivine City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Olivine City') }"
           d="M 65.4 136.2 l 6.63 -6.63 h 43 l 6.63 6.63 v 9.14 l -6.63 6.63 h -43 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -341,7 +341,7 @@
     <path class="city" data-town="Cianwood City"
           data-bind="
           click:function(){MapHelper.moveToTown('Cianwood City')},
-          attr: { class: MapHelper.calculateTownCssClass('Cianwood City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Cianwood City') }"
           d="M 37 289 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -354,7 +354,7 @@
     <path class="city" data-town="Mahogany Town"
           data-bind="
           click:function(){MapHelper.moveToTown('Mahogany Town')},
-          attr: { class: MapHelper.calculateTownCssClass('Mahogany Town')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Mahogany Town') }"
           d="M 376 73 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -367,7 +367,7 @@
     <path class="city" data-town="Blackthorn City"
           data-bind="
           click:function(){MapHelper.moveToTown('Blackthorn City')},
-          attr: { class: MapHelper.calculateTownCssClass('Blackthorn City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Blackthorn City') }"
           d="M 468 104 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -380,7 +380,7 @@
     <path class="city" data-town="Indigo Plateau 2.0"
           data-bind="
           click:function(){MapHelper.moveToTown('Indigo Plateau 2.0')},
-          attr: { class: MapHelper.calculateTownCssClass('Indigo Plateau 2.0')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Indigo Plateau 2.0') }"
           d="M 622 73 l 6.63 -6.63 h 9.14 l 6.63 6.63 v 9.14 l -6.63 6.63 h -9.14 l -6.63 -6.63 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4">
@@ -391,7 +391,7 @@
           x="292" y="126"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Violet City')},
-    attr: { class: MapHelper.calculateTownCssClass('Sprout Tower')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Sprout Tower') }"
           class="city" data-town="Sprout Tower"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="293" y="127"></rect>
@@ -401,7 +401,7 @@
           x="287" y="326"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Union Cave')},
-    attr: { class: MapHelper.calculateTownCssClass('Union Cave')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Union Cave') }"
           class="city" data-town="Union Cave"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="288" y="327"></rect>
@@ -411,7 +411,7 @@
           x="200" y="370"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Azalea Town')},
-    attr: { class: MapHelper.calculateTownCssClass('Slowpoke Well')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Slowpoke Well') }"
           class="city" data-town="Slowpoke Well"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="201" y="371"></rect>
@@ -421,7 +421,7 @@
           x="160" y="370"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Ilex Forest')},
-    attr: { class: MapHelper.calculateTownCssClass('Ilex Forest')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Ilex Forest') }"
           class="city" data-town="Ilex Forest"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="161" y="371"></rect>
@@ -431,7 +431,7 @@
           x="215" y="50"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Burned Tower')},
-    attr: { class: MapHelper.calculateTownCssClass('Burned Tower')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Burned Tower') }"
           class="city" data-town="Burned Tower"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="216" y="51"></rect>
@@ -441,7 +441,7 @@
           x="235" y="50"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Tin Tower')},
-    attr: { class: MapHelper.calculateTownCssClass('Tin Tower')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Tin Tower') }"
           class="city" data-town="Tin Tower"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="236" y="51"></rect>
@@ -451,7 +451,7 @@
           x="72" y="270"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Whirl Islands')},
-    attr: { class: MapHelper.calculateTownCssClass('Whirl Islands')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Whirl Islands') }"
           class="city" data-town="Whirl Islands"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="73" y="271"></rect>
@@ -461,7 +461,7 @@
           x="325" y="70"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Mt Mortar')},
-    attr: { class: MapHelper.calculateTownCssClass('Mt Mortar')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Mt Mortar') }"
           class="city" data-town="Mt Mortar"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="326" y="71"></rect>
@@ -471,7 +471,7 @@
           x="470" y="70"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Ice Path')},
-    attr: { class: MapHelper.calculateTownCssClass('Ice Path')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Ice Path') }"
           class="city" data-town="Ice Path"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="471" y="71"></rect>
@@ -481,7 +481,7 @@
           x="465" y="179"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Dark Cave')},
-    attr: { class: MapHelper.calculateTownCssClass('Dark Cave')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Dark Cave') }"
           class="city" data-town="Dark Cave"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="466" y="180"></rect>
@@ -491,7 +491,7 @@
           x="525" y="224"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Mt Silver')},
-    attr: { class: MapHelper.calculateTownCssClass('Mt Silver')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Mt Silver') }"
           class="city" data-town="Mt Silver"
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="526" y="225"></rect>
@@ -501,5 +501,5 @@
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="98" y="155"
           data-bind="click:function(){MapHelper.openShipModal()}"></rect>
-    
+
 </g>

--- a/src/components/KantoSVG.html
+++ b/src/components/KantoSVG.html
@@ -5,7 +5,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(1, 0); } ">
         <rect data-route='1'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(1,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(1,0) }"
               height="28"
               width="80.1"
               x="51.3" y="250.2"></rect>
@@ -16,7 +16,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(2, 0); } ">
         <rect data-route='2'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(2,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(2,0) }"
               height="28"
               width="120.1"
               x="-70" y="250.2"></rect>
@@ -26,7 +26,7 @@
     <!--Route 3-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(3, 0); } ">
         <rect data-route='3'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(3,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(3,0) }"
               height="28"
               width="112.1"
               x="92.3" y="100.1"></rect>
@@ -36,7 +36,7 @@
     <!--Route 4-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(4, 0); } ">
         <rect data-route='4'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(4,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(4,0) }"
               height="28"
               width="170"
               x="174.3" y="72.8"></rect>
@@ -47,7 +47,7 @@
     <g transform="rotate(90,31.5,9.5)"
        data-bind="click:function(){ MapHelper.moveToRoute(5, 0); } ">
         <rect data-route='5'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(5,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(5,0) }"
               height="28"
               width="70"
               x="120" y="-324"></rect>
@@ -58,7 +58,7 @@
     <g transform="rotate(90,31.5,9.5)"
        data-bind="click:function(){ MapHelper.moveToRoute(6, 0); } ">
         <rect data-route='6'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(6,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(6,0) }"
               height="28"
               width="70"
               x="200" y="-324"></rect>
@@ -68,7 +68,7 @@
     <!--Route 7-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(7, 0); } ">
         <rect data-route='7'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(7,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(7,0) }"
               height="28"
               width="112.1"
               x="345.3" y="152.1"></rect>
@@ -78,7 +78,7 @@
     <!--Route 8-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(8, 0); } ">
         <rect data-route='8'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(8,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(8,0) }"
               height="28"
               width="90.1"
               x="270.3" y="152.1"></rect>
@@ -88,7 +88,7 @@
     <!--Route 9-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(9, 0); } ">
         <rect data-route='9'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(9,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(9,0) }"
               height="28"
               width="112.1"
               x="345.3" y="72.8"></rect>
@@ -98,7 +98,7 @@
     <!--Route 10-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(10, 0); } ">
         <rect data-route='10'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(10,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(10,0) }"
               height="28"
               width="90"
               transform="rotate(90,31.5,9.5)"
@@ -109,7 +109,7 @@
     <!--Route 11-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(11, 0); } ">
         <rect data-route='11'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(11,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(11,0) }"
               height="28"
               width="99.3"
               x="345.3" y="231.8"></rect>
@@ -120,7 +120,7 @@
     <g transform="rotate(90,31.5,9.5)"
        data-bind="click:function(){ MapHelper.moveToRoute(12, 0); } ">
         <rect data-route='12'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(12,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(12,0) }"
               height="28"
               width="82"
               x="200" y="-430"></rect>
@@ -131,7 +131,7 @@
     <g transform="rotate(90,31.5,9.5)"
        data-bind="click:function(){ MapHelper.moveToRoute(13, 0); } ">
         <rect data-route='13'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(13,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(13,0) }"
               height="28"
               width="56"
               x="281" y="-430"></rect>
@@ -141,7 +141,7 @@
     <!--Route 14-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(14, 0); } ">
         <rect data-route='14'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(14,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(14,0) }"
               height="28"
               width="80.3"
               x="363.3" y="287"></rect>
@@ -151,7 +151,7 @@
     <!--Route 15-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(15, 0); } ">
         <rect data-route='15'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(15,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(15,0) }"
               height="28"
               width="101.3"
               x="290.3" y="314"></rect>
@@ -161,7 +161,7 @@
     <!--Route 16-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(16, 0); } ">
         <rect data-route='16'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(16,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(16,0) }"
               height="28"
               width="130.1"
               x="148.3" y="152.1"></rect>
@@ -172,7 +172,7 @@
     <g transform="rotate(90,31.5,9.5)"
        data-bind="click:function(){ MapHelper.moveToRoute(17, 0); } ">
         <rect data-route='17'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(17,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(17,0) }"
               height="28"
               width="137"
               x="200" y="-135.3"></rect>
@@ -182,7 +182,7 @@
     <!--Route 18-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(18, 0); } ">
         <rect data-route='18'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(18,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(18,0) }"
               height="28"
               width="145.3"
               x="148.3" y="314"></rect>
@@ -193,7 +193,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(19, 0); } ">
         <rect data-route='19'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(19,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(19,0) }"
               height="28"
               width="64"
               x="151.3" y="35.2"></rect>
@@ -202,7 +202,7 @@
     <!--Route 19-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(19, 0); } ">
         <rect data-route='19'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(19,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(19,0) }"
               height="28"
               width="105.3"
               x="188.3" y="367"></rect>
@@ -212,7 +212,7 @@
     <!--Route 20-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(20, 0); } ">
         <rect data-route='20'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(20,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(20,0) }"
               height="28"
               width="99"
               x="90.3" y="367"></rect>
@@ -223,7 +223,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(21, 0); } ">
         <rect data-route='21'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(21,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(21,0) }"
               height="28"
               width="80.1"
               x="121.3" y="250.2"></rect>
@@ -235,7 +235,7 @@
     <!--Route 22-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(22, 0); } ">
         <rect data-route='22'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(22,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(22,0) }"
               height="28"
               width="75"
               x="15.3" y="205"></rect>
@@ -246,7 +246,7 @@
     <g transform="rotate(90,83.65,263.2)"
        data-bind="click:function(){ MapHelper.moveToRoute(23, 0); } ">
         <rect data-route='23'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(23,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(23,0) }"
               height="28"
               width="116"
               x="-90" y="304"></rect>
@@ -256,7 +256,7 @@
     <!--Route 24-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(24, 0); } ">
         <rect data-route='24' transform="rotate(90,31.5,9.5)"
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(24,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(24,0) }"
               height="28"
               width="40"
               x="67" y="-324"></rect>
@@ -266,7 +266,7 @@
     <!--Route 25-->
     <g data-bind="click:function(){ MapHelper.moveToRoute(25, 0); } ">
         <rect data-route='25'
-              data-bind="attr: { class: MapHelper.calculateRouteCssClass(25,0)() }"
+              data-bind="attr: { class: MapHelper.calculateRouteCssClass(25,0) }"
               height="28"
               width="83"
               x="337" y="18"></rect>
@@ -279,7 +279,7 @@
     <path class="city" data-town="Pewter City"
           data-bind="
           click:function(){MapHelper.moveToTown('Pewter City')},
-          attr: { class: MapHelper.calculateTownCssClass('Pewter City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Pewter City') }"
           d="M 72.8 109.53 L 79.43 102.9 L 88.57 102.9 L 95.2 109.53 L 95.2 118.67 L 88.57 125.3 L 79.43 125.3 L 72.8 118.67 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -289,7 +289,7 @@
     <path class="city" data-town="Viridian City"
           data-bind="
           click:function(){MapHelper.moveToTown('Viridian City')},
-          attr: { class: MapHelper.calculateTownCssClass('Viridian City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Viridian City') }"
           d="M 72.8 216.63 L 79.43 210 L 88.57 210 L 95.2 216.63 L 95.2 225.77 L 88.57 232.4 L 79.43 232.4 L 72.8 225.77 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -299,7 +299,7 @@
     <path class="city" data-town="Pallet Town"
           data-bind="
           click:function(){MapHelper.moveToTown('Pallet Town')},
-          attr: { class: MapHelper.calculateTownCssClass('Pallet Town')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Pallet Town') }"
           d="M 72.1 297.83 L 78.73 291.2 L 87.87 291.2 L 94.5 297.83 L 94.5 306.97 L 87.87 313.6 L 78.73 313.6 L 72.1 306.97 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -309,7 +309,7 @@
     <path class="city" data-town="Saffron City"
           data-bind="
           click:function(){MapHelper.moveToTown('Saffron City')},
-          attr: { class: MapHelper.calculateTownCssClass('Saffron City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Saffron City') }"
           d="M 340.9 162.73 L 347.53 156.1 L 356.67 156.1 L 363.3 162.73 L 363.3 171.87 L 356.67 178.5 L 347.53 178.5 L 340.9 171.87 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke=
                   "#b85450" stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -319,7 +319,7 @@
     <path class="city" data-town="Celadon City"
           data-bind="
           click:function(){MapHelper.moveToTown('Celadon City')},
-          attr: { class: MapHelper.calculateTownCssClass('Celadon City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Celadon City') }"
           d="M 256.9 162.73 L 263.53 156.1 L 272.67 156.1 L 279.3 162.73 L 279.3 171.87 L 272.67 178.5 L 263.53 178.5 L 256.9 171.87 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke=
                   "#b85450" stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -329,7 +329,7 @@
     <path class="city" data-town="Vermillion City"
           data-bind="
           click:function(){MapHelper.moveToTown('Vermillion City')},
-          attr: { class: MapHelper.calculateTownCssClass('Vermillion City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Vermillion City') }"
           d="M 339.5 242.53 L 346.13 235.9 L 355.27 235.9 L 361.9 242.53 L 361.9 251.67 L 355.27 258.3 L 346.13 258.3 L 339.5 251.67 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke=
                   "#b85450" stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -339,7 +339,7 @@
     <path class="city" data-town="Indigo Plateau"
           data-bind="
           click:function(){MapHelper.moveToTown('Indigo Plateau')},
-          attr: { class: MapHelper.calculateTownCssClass('Indigo Plateau')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Indigo Plateau') }"
           d="M 18.9 82.23 L 25.53 75.6 L 34.67 75.6 L 41.3 82.23 L 41.3 91.37 L 34.67 98 L 25.53 98 L 18.9 91.37 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -349,7 +349,7 @@
     <path class="city" data-town="Cerulean City"
           data-bind="
           click:function(){MapHelper.moveToTown('Cerulean City')},
-          attr: { class: MapHelper.calculateTownCssClass('Cerulean City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Cerulean City') }"
           d="M 340.9 80.83 L 347.53 74.2 L 356.67 74.2 L 363.3 80.83 L 363.3 89.97 L 356.67 96.6 L 347.53 96.6 L 340.9 89.97 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -359,7 +359,7 @@
     <path class="city" data-town="Lavender Town"
           data-bind="
           click:function(){MapHelper.moveToTown('Lavender Town')},
-          attr: { class: MapHelper.calculateTownCssClass('Lavender Town')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Lavender Town') }"
           d="M 448 164.13 L 454.63 157.5 L 463.77 157.5 L 470.4 164.13 L 470.4 173.27 L 463.77 179.9 L 454.63 179.9 L 448 173.27 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -369,7 +369,7 @@
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           data-bind="
           click:function(){MapHelper.moveToTown('Lavender Town')},
-          attr: { class: MapHelper.calculateTownCssClass('Lavender Town')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Lavender Town') }"
           height="12.6" stroke="#6c8ebf" width="12.6" x="457.8" y="168"></rect>
     <path d="M 284.2 323.29 L 292.49 315 L 303.91 315 L 312.2 323.29 L 312.2 334.71 L 303.91 343 L 292.49 343 L 284.2 334.71 Z"
           fill="#ffffff" stroke="#000000" stroke-miterlimit="10" stroke-width=
@@ -377,7 +377,7 @@
     <path class="city" data-town="Fuchsia City"
           data-bind="
           click:function(){MapHelper.moveToTown('Fuchsia City')},
-          attr: { class: MapHelper.calculateTownCssClass('Fuchsia City')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Fuchsia City') }"
           d="M 287 324.43 L 293.63 317.8 L 302.77 317.8 L 309.4 324.43 L 309.4 333.57 L 302.77 340.2 L 293.63 340.2 L 287 333.57 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -390,7 +390,7 @@
     <path class="city" data-town="Cinnabar Island"
           data-bind="
           click:function(){MapHelper.moveToTown('Cinnabar Island')},
-          attr: { class: MapHelper.calculateTownCssClass('Cinnabar Island')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Cinnabar Island') }"
           d="M 72.8 376.93 L 79.43 370.3 L 88.57 370.3 L 95.2 376.93 L 95.2 386.07 L 88.57 392.7 L 79.43 392.7 L 72.8 386.07 Z"
           fill="url(#mx-gradient-f8cecc-1-ea583b-1-s-0)" stroke="#b85450"
           stroke-miterlimit="10" stroke-width="1.4"></path>
@@ -400,7 +400,7 @@
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           data-bind="
           click:function(){MapHelper.moveToTown('Cinnabar Island')},
-          attr: { class: MapHelper.calculateTownCssClass('Cinnabar Island')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Cinnabar Island') }"
           height="12.6" stroke="#6c8ebf" width="12.6" x="82.6" y="380.8"></rect>
 
     <rect fill="#ffffff" height="15.4" stroke="none" width="15.4" x="349.3"
@@ -409,14 +409,14 @@
           fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           data-bind="
           click:function(){MapHelper.moveToTown('Cerulean City')},
-          attr: { class: MapHelper.calculateTownCssClass('Cerulean Cave')() }"
+          attr: { class: MapHelper.calculateTownCssClass('Cerulean Cave') }"
           height="12.6" stroke="#6c8ebf" width="12.6" x="350.7" y="84.7"></rect>
 
     <rect fill="#ffffff" height="15.4" stroke="none" width="15.4" x="22.4"
           y="109.9"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Victory Road')},
-    attr: { class: MapHelper.calculateTownCssClass('Victory Road')() }" 
+    attr: { class: MapHelper.calculateTownCssClass('Victory Road') }"
     class="city"
     data-town="Victory Road" fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="23.8" y="111.3"></rect>
@@ -425,7 +425,7 @@
           y="133"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Digletts Cave')},
-    attr: { class: MapHelper.calculateTownCssClass('Digletts Cave')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Digletts Cave') }"
           class="city"
           data-town="Digletts Cave" fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="77.7" y="134.4"></rect>
@@ -434,7 +434,7 @@
           y="156.1"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Viridian Forest')},
-    attr: { class: MapHelper.calculateTownCssClass('Viridian Forest')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Viridian Forest') }"
           class="city"
           data-town="Viridian Forest" fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="77.7" y="157.5"></rect>
@@ -443,7 +443,7 @@
           y="374.5"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Seafoam Islands')},
-    attr: { class: MapHelper.calculateTownCssClass('Seafoam Islands')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Seafoam Islands') }"
           class="city"
           data-town="Seafoam Islands" fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6" stroke="#6c8ebf" width="12.6" x="182.7" y="375.9"></rect>
@@ -452,7 +452,7 @@
           y="90"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Mt. Moon')},
-    attr: { class: MapHelper.calculateTownCssClass('Mt. Moon')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Mt. Moon') }"
     class="city"
     data-town="Mt. Moon" fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6"
@@ -465,7 +465,7 @@
           y="79.1"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Rock Tunnel')},
-    attr: { class: MapHelper.calculateTownCssClass('Rock Tunnel')() }"
+    attr: { class: MapHelper.calculateTownCssClass('Rock Tunnel') }"
           class="city"
           data-town="Rock Tunnel" fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6"
@@ -475,7 +475,7 @@
           y="103.6"></rect>
     <rect data-bind="
     click:function(){MapHelper.moveToTown('Power Plant')},
-    attr: { class: MapHelper.calculateTownCssClass('Power Plant')() }" class="city"
+    attr: { class: MapHelper.calculateTownCssClass('Power Plant') }" class="city"
           data-town="Power Plant" fill="url(#mx-gradient-dae8fc-1-7ea6e0-1-s-0)"
           height="12.6"
           stroke="#6c8ebf" width="12.6" x="452.9" y="105"></rect>

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -53,7 +53,7 @@ class MapHelper {
         return "lockedRoute";
     }
 
-    public static calculateTownCssClass(town: string): KnockoutComputed<string> {
+    public static calculateTownCssClass(town: string): string {
         if (player.currentTown() == town) {
             return "city currentTown";
         }

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -3,11 +3,15 @@ class MapHelper {
     public static moveToRoute = function (route: number, region: GameConstants.Region) {
         if (!isNaN(route) && !(route == player.route())) {
             if (this.accessToRoute(route, region)) {
-                $("[data-route='" + player.route() + "']").removeClass('currentRoute').addClass('unlockedRoute');
+                const oldRoute = document.querySelector("[data-route='" + player.route() + "']");
+                oldRoute.classList.remove('currentRoute');
+                oldRoute.classList.add('unlockedRoute');
                 player.route(route);
                 player.region = region;
                 player.currentTown("");
-                $("[data-route='" + route + "']").removeClass('unlockedRoute').addClass('currentRoute');
+                const newRoute = document.querySelector("[data-route='" + route + "']");
+                newRoute.classList.remove('unlockedRoute');
+                newRoute.classList.add('currentRoute');
                 Battle.generateNewEnemy();
                 Game.gameState(GameConstants.GameState.fighting);
                 Game.applyRouteBindings();

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -3,15 +3,9 @@ class MapHelper {
     public static moveToRoute = function (route: number, region: GameConstants.Region) {
         if (!isNaN(route) && !(route == player.route())) {
             if (this.accessToRoute(route, region)) {
-                const oldRoute = document.querySelector("[data-route='" + player.route() + "']");
-                oldRoute.classList.remove('currentRoute');
-                oldRoute.classList.add('unlockedRoute');
                 player.route(route);
                 player.region = region;
-                player.currentTown("");
-                const newRoute = document.querySelector("[data-route='" + route + "']");
-                newRoute.classList.remove('unlockedRoute');
-                newRoute.classList.add('currentRoute');
+                player.currentTown('');
                 Battle.generateNewEnemy();
                 Game.gameState(GameConstants.GameState.fighting);
                 Game.applyRouteBindings();

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -43,37 +43,33 @@ class MapHelper {
         return MapHelper.hasBadgeReq(route, region) && MapHelper.hasDungeonReq(route, region) && MapHelper.hasRouteKillReq(route, region);
     };
 
-    public static calculateRouteCssClass(route: number, region: GameConstants.Region): KnockoutComputed<string> {
-        return ko.computed(function () {
-            if (player.route() == route && player.region == region) {
-                return "currentRoute";
-            }
-            if (MapHelper.accessToRoute(route, region)) {
-                return "unlockedRoute";
-            }
-            return "lockedRoute";
-        });
+    public static calculateRouteCssClass(route: number, region: GameConstants.Region): string {
+        if (player.route() == route && player.region == region) {
+            return "currentRoute";
+        }
+        if (MapHelper.accessToRoute(route, region)) {
+            return "unlockedRoute";
+        }
+        return "lockedRoute";
     }
 
     public static calculateTownCssClass(town: string): KnockoutComputed<string> {
-        return ko.computed(function () {
-            if (player.currentTown() == town) {
-                return "city currentTown";
-            }
-            if (MapHelper.accessToTown(town)) {
-                if (dungeonList.hasOwnProperty(town)) {
-                    if (DungeonRunner.dungeonCompleted(dungeonList[town], false)) {
-                        return "dungeon completedDungeon"
-                    }
-                    return "dungeon unlockedDungeon"
-                }
-                return "city unlockedTown";
-            }
+        if (player.currentTown() == town) {
+            return "city currentTown";
+        }
+        if (MapHelper.accessToTown(town)) {
             if (dungeonList.hasOwnProperty(town)) {
-                return "dungeon"
+                if (DungeonRunner.dungeonCompleted(dungeonList[town], false)) {
+                    return "dungeon completedDungeon"
+                }
+                return "dungeon unlockedDungeon"
             }
-            return "city";
-        });
+            return "city unlockedTown";
+        }
+        if (dungeonList.hasOwnProperty(town)) {
+            return "dungeon"
+        }
+        return "city";
     }
 
     public static accessToTown(townName: string): boolean {


### PR DESCRIPTION
closes #332 it should reduce the amount of memory used to around ~25-50%

It may still need some more investigating, but this should help a ton.

I've removed the knockout bindings, the map seems to update properly without them though:

memory usage over 20 seconds using the following script:
```javascript
setInterval(()=>{
	MapHelper.moveToRoute(Math.floor(Math.random() * 6) + 1, 0);
}, 10);
```

Before | After
:--: | :--:
`88MB`→ `562MB` | `85.9MB`→`224MB`
![memory-usage-withko](https://user-images.githubusercontent.com/7288322/59145550-81629000-8a39-11e9-95d1-ebf9bda270fc.gif) | ![memory-usage-noko](https://user-images.githubusercontent.com/7288322/59145551-88899e00-8a39-11e9-8886-9a3ac97c53fd.gif)