### PR TITLE
Set max catch rate to 100%

### DIFF
--- a/src/scripts/Battle.ts
+++ b/src/scripts/Battle.ts
@@ -92,7 +92,7 @@ class Battle {
         let pokeballBonus = GameConstants.getCatchBonus(pokeBall);
         let oakBonus = OakItemRunner.isActive(GameConstants.OakItem.Magic_Ball) ? 
             OakItemRunner.calculateBonus(GameConstants.OakItem.Magic_Ball) : 0;
-        let totalChance = this.enemyPokemon().catchRate + pokeballBonus + oakBonus;
+        let totalChance = GameConstants.clipNumber(this.enemyPokemon().catchRate + pokeballBonus + oakBonus, 0, 100);
         return totalChance;
     }
 


### PR DESCRIPTION
Previously, only the Pokemon's own catch rate was clipped to be between 0 and 100. But after Oak + Pokeball bonus, this could be outside that range.