### PR TITLE
Check mine evo stones through the EvolutionStone class

### DIFF
--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -72,14 +72,6 @@ namespace GameConstants {
         "Hammer" = 1,
     }
 
-    export const EvoStones = [
-        "Fire Stone",
-        "Water Stone",
-        "Thunder Stone",
-        "Leaf Stone",
-        "Moon Stone"
-    ];
-
     export const PLATE_VALUE = 25;
 
     // Oak items

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -62,13 +62,8 @@ class Underground {
         let item = Underground.getMineItemById(id);
         
         if(item.isStone()){
-            let evostone = ItemList[item.valueType];
-            if (evostone instanceof EvolutionStone) {
-                evostone.buy(num)
-            } else {
-                console.log("Error getting evolution stone",num,id,item)
-                Notifier.notify("Error getting evolution stone",GameConstants.NotificationOption.warning)
-            }
+            let evostone: EvolutionStone = ItemList[item.valueType];
+            evostone.buy(num);
             return;
         }
         

--- a/src/scripts/underground/UndergroundItem.ts
+++ b/src/scripts/underground/UndergroundItem.ts
@@ -76,7 +76,7 @@ class UndergroundItem {
     }
 
     public isStone(): boolean {
-        return (GameConstants.EvoStones.indexOf(this.name) > -1)
+        return ItemList[this.valueType] instanceof EvolutionStone;
     }
 
     public static getFullResourceName(valuetype: string, amt: number): string {


### PR DESCRIPTION
Previously, Sun stone wasn't coded as an "evolution stone" in the mine, resulting in this error:

![image](https://user-images.githubusercontent.com/36806183/59318368-d0583180-8c94-11e9-801a-3a788ce84cae.png)

Now, remove the separate hard-coded list of evo stones used in the mine, and use `EvolutionStone` class to check for stones instead.