### PR TITLE
Allow base form to be captured as result of breeding

### DIFF
--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -405,6 +405,9 @@ class Player {
     }
 
     public capturePokemon(pokemonName: string, shiny: boolean = false, supressNotification = false) {
+        if (PokemonHelper.calcNativeRegion(pokemonName) > player.highestRegion) {
+            return;
+        }
         OakItemRunner.use(GameConstants.OakItem.Magic_Ball);
         let pokemonData = PokemonHelper.getPokemonByName(pokemonName);
         if (!this.alreadyCaughtPokemon(pokemonName)) {

--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -62,6 +62,13 @@ class BreedingHelper {
             }
         }
         player.capturePokemon(egg.pokemon, shiny);
+
+        // Capture base form if not already caught. This helps players get Gen2 Pokemon that are base form of Gen1
+        let baseForm = BreedingHelper.calculateBaseForm(egg.pokemon);
+        if (egg.pokemon != baseForm && !player.alreadyCaughtPokemon(baseForm)) {
+            player.capturePokemon(baseForm, false);
+        }
+
         player._eggList[index](null);
         GameHelper.incrementObservable(player.statistics.hatchedEggs);
         OakItemRunner.use(GameConstants.OakItem.Blaze_Cassette);
@@ -110,6 +117,20 @@ class BreedingHelper {
 
     public static getEggSlotCost(slot: number): number {
         return 500 * slot;
+    }
+
+    public static calculateBaseForm(pokemonName: string): string {
+        // Base form of Pokemon depends on which regions players unlocked
+        if (!(pokemonName in pokemonDevolutionMap)) {
+            // No devolutions at all
+            return pokemonName;
+        } else if (PokemonHelper.calcNativeRegion(pokemonDevolutionMap[pokemonName]) > player.highestRegion) {
+            // No further devolutions in current unlocked regions
+            return pokemonName;
+        } else {
+            // Recurse onto its devolution
+            return BreedingHelper.calculateBaseForm(pokemonDevolutionMap[pokemonName]);
+        }
     }
 }
 

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -5,6 +5,7 @@
 
 const pokemonMap: { [name: string]: any } = {};
 const pokemonMapId: { [id: number]: any } = {};
+const pokemonDevolutionMap: {[name: string]: string} = {};
 
 /**
  * Datalist that contains all Pokémon data
@@ -3369,4 +3370,7 @@ for (let i = 0; i < pokemonList.length; i++) {
     let p = pokemonList[i];
     pokemonMap[p["name"]] = p;
     pokemonMapId[i + 1] = p;
+    if (p.hasOwnProperty("evolution")) {
+        p["evolution"].split(", ").forEach(x => {pokemonDevolutionMap[x] = p["name"]});        
+    }
 }


### PR DESCRIPTION
Previous breeding behavior: after done breeding X, only capture X.

New breeding behavior: after done breeding X, capture X. And also capture its base form Y, where Y is the most primitive form from a region that player has unlocked, and where Y is not yet caught. 

This is controlled through `pokemonDevolutionMap` and `BreedingHelper.calculateBaseForm`. Examples:
- If player has only unlocked Kanto, then Raichu's base form is Pikachu
- If player has unlocked Johto, then Raichu's base form becomes Pichu.

When Pichu is caught by breeding Raichu after unlocking Johto:
![image](https://user-images.githubusercontent.com/36806183/59546658-db62ca00-8eff-11e9-84eb-89ad58d6a515.png)

This will allow the capture of Pichu, Cleffa, Igglybuff, Smoochum, Elekid, and Elekid. #363 